### PR TITLE
Fix typos in Introduction

### DIFF
--- a/doc/EASTL Introduction.html
+++ b/doc/EASTL Introduction.html
@@ -21,14 +21,14 @@
   this case you need to understand that templates, when used properly, are powerful 
   vehicles for the ease of creation of optimized C++ code. A description of C++ 
   templates is outside the scope of this documentation, but there is plenty of such 
-  documentation on the Interent. See the <a href="EASTL%20FAQ.html">EASTL FAQ.html</a> 
+  documentation on the Internet. See the <a href="EASTL%20FAQ.html">EASTL FAQ.html</a> 
   document for links to information related to learning templates and STL.</p>
 <h2>EASTL Modules</h2>
 <p>EASTL consists primarily of containers, algorithms, and iterators. An example of a container is a linked list, while an
   example of an algorithm is a sort function; iterators are the entities of traversal for containers and algorithms.
   EASTL containers a fairly large number of containers and algorithms, each of which is a very clean, efficient, and
   unit-tested implementation. We can say with some confidence that you are not likely to find better implementations of
-  these (commerical or otherwise), as these are the result of years of wisdom and diligent work. For a detailed list of
+  these (commercial or otherwise), as these are the result of years of wisdom and diligent work. For a detailed list of
   EASTL modules, see <a href="EASTL%20Modules.html">EASTL Modules.html</a>.</p>
 <h2>EASTL Suitability</h2>
 <p>What uses are EASTL suitable for? Essentially any situation in tools and shipping applications where the functionality


### PR DESCRIPTION
`Interent` → `Internet`
`commerical` → `commercial`