### PR TITLE
Include EASTL from the test folder, but allow EASTL to be built separately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,36 @@ if( UNIX AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fasm-blocks" )
 endif()
 
+if(UNIX)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
 #-------------------------------------------------------------------------------------------
 # Include dirs
 #-------------------------------------------------------------------------------------------
 target_include_directories(EASTL PUBLIC include ${PROJECT_SOURCE_DIR}/test/packages/EABase/include/Common)
 target_link_libraries(EASTL EABase)
+
+#-------------------------------------------------------------------------------------------
+# Libraries
+#-------------------------------------------------------------------------------------------
+add_subdirectory(test/packages/EAAssert)
+add_subdirectory(test/packages/EABase)
+add_subdirectory(test/packages/EAStdC)
+add_subdirectory(test/packages/EAMain)
+add_subdirectory(test/packages/EAThread)
+
+set(EASTL_Libraries
+    EAAssert
+    EABase
+    EAMain
+    EAStdC
+    EAThread
+    EATest)
+target_link_libraries(EASTL ${EASTL_Libraries})
+
+#-------------------------------------------------------------------------------------------
+# Defines
+#-------------------------------------------------------------------------------------------
+add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+add_definitions(-DEASTL_OPENSOURCE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,16 +26,11 @@ endif()
 #-------------------------------------------------------------------------------------------
 # Libraries 
 #-------------------------------------------------------------------------------------------
-add_subdirectory(packages/EAAssert)
-add_subdirectory(packages/EABase)
-add_subdirectory(packages/EAMain)
-add_subdirectory(packages/EAStdC)
 add_subdirectory(packages/EATest)
-add_subdirectory(packages/EAThread)
 add_subdirectory(../ "${CMAKE_CURRENT_BINARY_DIR}/eastl")
 
 #-------------------------------------------------------------------------------------------
-# Source files 
+# Source files
 #-------------------------------------------------------------------------------------------
 file(GLOB EASTLTEST_SOURCES "source/*.cpp")
 set(SOURCES ${EASTLTEST_SOURCES})
@@ -44,9 +39,11 @@ set(SOURCES ${EASTLTEST_SOURCES})
 # Defines 
 #-------------------------------------------------------------------------------------------
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-add_definitions(-DEASTL_THREAD_SUPPORT_AVAILABLE=0) 
 add_definitions(-DEASTL_OPENSOURCE)
 add_definitions(-D_CHAR16T)
+# Thread support is disabled in order to test our implementation
+add_definitions(-DEASTL_THREAD_SUPPORT_AVAILABLE=0)
+target_compile_definitions(EASTL PUBLIC -DEASTL_THREAD_SUPPORT_AVAILABLE=0)
 
 #-------------------------------------------------------------------------------------------
 # Executable definition
@@ -54,12 +51,7 @@ add_definitions(-D_CHAR16T)
 add_executable(EASTLTest ${SOURCES})
 
 set(EASTLTest_Libraries
-    EAAssert
-    EABase
-    EAMain
     EASTL
-    EAStdC
-	EAThread
     EATest)
 target_link_libraries(EASTLTest ${EASTLTest_Libraries})
 


### PR DESCRIPTION
This will allow building EASTL separate from the tests.  Now EASTL can be used from a CMake project via `add_subdirectory(EASTL)`. The `test` folder became just an example of that.

I assumed `EASTL_THREAD_SUPPORT_AVAILABLE` is defined to `0` in the `test` build to allow the test code to use the EASTL thread support. Please tell if it's not true.

I ran two verbose builds to make sure the defines were correct.

Build in the root folder:

```
felipe@Felipes-MacBook-Pro:~/code/proto3d/EASTL (cmake-version *%)$ cmake -Bbuild -H. -DCMAKE_VERBOSE_MAKEFILE=ON && make -C build
-- The C compiler identification is AppleClang 6.1.0.6020049
-- The CXX compiler identification is AppleClang 6.1.0.6020049
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/felipe/code/proto3d/EASTL/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -H/Users/felipe/code/proto3d/EASTL -B/Users/felipe/code/proto3d/EASTL/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_start /Users/felipe/code/proto3d/EASTL/build/CMakeFiles /Users/felipe/code/proto3d/EASTL/build/CMakeFiles/progress.marks
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/Makefile2 all
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f test/packages/EAStdC/CMakeFiles/EAStdC.dir/build.make test/packages/EAStdC/CMakeFiles/EAStdC.dir/depend
cd /Users/felipe/code/proto3d/EASTL/build && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_depends "Unix Makefiles" /Users/felipe/code/proto3d/EASTL /Users/felipe/code/proto3d/EASTL/test/packages/EAStdC /Users/felipe/code/proto3d/EASTL/build /Users/felipe/code/proto3d/EASTL/build/test/packages/EAStdC /Users/felipe/code/proto3d/EASTL/build/test/packages/EAStdC/CMakeFiles/EAStdC.dir/DependInfo.cmake --color=
Scanning dependencies of target EAStdC
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f test/packages/EAStdC/CMakeFiles/EAStdC.dir/build.make test/packages/EAStdC/CMakeFiles/EAStdC.dir/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 10
[  9%] Building CXX object test/packages/EAStdC/CMakeFiles/EAStdC.dir/source/EAMemory.cpp.o
cd /Users/felipe/code/proto3d/EASTL/build/test/packages/EAStdC && /usr/bin/c++   -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include    -o CMakeFiles/EAStdC.dir/source/EAMemory.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/source/EAMemory.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 11
[ 18%] Building CXX object test/packages/EAStdC/CMakeFiles/EAStdC.dir/source/EASprintf.cpp.o
cd /Users/felipe/code/proto3d/EASTL/build/test/packages/EAStdC && /usr/bin/c++   -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include    -o CMakeFiles/EAStdC.dir/source/EASprintf.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/source/EASprintf.cpp
Linking CXX static library libEAStdC.a
cd /Users/felipe/code/proto3d/EASTL/build/test/packages/EAStdC && /usr/local/Cellar/cmake/3.1.3/bin/cmake -P CMakeFiles/EAStdC.dir/cmake_clean_target.cmake
cd /Users/felipe/code/proto3d/EASTL/build/test/packages/EAStdC && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_link_script CMakeFiles/EAStdC.dir/link.txt --verbose=1
/usr/bin/ar cq libEAStdC.a  CMakeFiles/EAStdC.dir/source/EAMemory.cpp.o CMakeFiles/EAStdC.dir/source/EASprintf.cpp.o
/usr/bin/ranlib libEAStdC.a
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles  10 11
[ 18%] Built target EAStdC
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/EASTL.dir/build.make CMakeFiles/EASTL.dir/depend
cd /Users/felipe/code/proto3d/EASTL/build && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_depends "Unix Makefiles" /Users/felipe/code/proto3d/EASTL /Users/felipe/code/proto3d/EASTL /Users/felipe/code/proto3d/EASTL/build /Users/felipe/code/proto3d/EASTL/build /Users/felipe/code/proto3d/EASTL/build/CMakeFiles/EASTL.dir/DependInfo.cmake --color=
Scanning dependencies of target EASTL
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/EASTL.dir/build.make CMakeFiles/EASTL.dir/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 1
[ 27%] Building CXX object CMakeFiles/EASTL.dir/source/allocator_eastl.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/allocator_eastl.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/allocator_eastl.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 2
[ 36%] Building CXX object CMakeFiles/EASTL.dir/source/assert.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/assert.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/assert.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 3
[ 45%] Building CXX object CMakeFiles/EASTL.dir/source/fixed_pool.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/fixed_pool.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/fixed_pool.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 4
[ 54%] Building CXX object CMakeFiles/EASTL.dir/source/hashtable.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/hashtable.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/hashtable.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 5
[ 63%] Building CXX object CMakeFiles/EASTL.dir/source/intrusive_list.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/intrusive_list.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/intrusive_list.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 6
[ 72%] Building CXX object CMakeFiles/EASTL.dir/source/numeric_limits.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/numeric_limits.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/numeric_limits.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 7
[ 81%] Building CXX object CMakeFiles/EASTL.dir/source/red_black_tree.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/red_black_tree.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/red_black_tree.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 8
[ 90%] Building CXX object CMakeFiles/EASTL.dir/source/string.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/string.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/string.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 9
[100%] Building CXX object CMakeFiles/EASTL.dir/source/thread_support.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EASTL.dir/source/thread_support.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/thread_support.cpp
Linking CXX static library libEASTL.a
/usr/local/Cellar/cmake/3.1.3/bin/cmake -P CMakeFiles/EASTL.dir/cmake_clean_target.cmake
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_link_script CMakeFiles/EASTL.dir/link.txt --verbose=1
/usr/bin/ar cq libEASTL.a  CMakeFiles/EASTL.dir/source/allocator_eastl.cpp.o CMakeFiles/EASTL.dir/source/assert.cpp.o CMakeFiles/EASTL.dir/source/fixed_pool.cpp.o CMakeFiles/EASTL.dir/source/hashtable.cpp.o CMakeFiles/EASTL.dir/source/intrusive_list.cpp.o CMakeFiles/EASTL.dir/source/numeric_limits.cpp.o CMakeFiles/EASTL.dir/source/red_black_tree.cpp.o CMakeFiles/EASTL.dir/source/string.cpp.o CMakeFiles/EASTL.dir/source/thread_support.cpp.o
/usr/bin/ranlib libEASTL.a
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/build/CMakeFiles  1 2 3 4 5 6 7 8 9
[100%] Built target EASTL
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_start /Users/felipe/code/proto3d/EASTL/build/CMakeFiles 0
```
Build in the test/ folder:

```
felipe@Felipes-MacBook-Pro:~/code/proto3d/EASTL/test (notest-build $%)$ cmake -Bbuild -H. -DCMAKE_VERBOSE_MAKEFILE=ON && make -C build
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/felipe/code/proto3d/EASTL/test/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -H/Users/felipe/code/proto3d/EASTL/test -B/Users/felipe/code/proto3d/EASTL/test/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_start /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles/progress.marks
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/Makefile2 all
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/build.make eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/depend
cd /Users/felipe/code/proto3d/EASTL/test/build && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_depends "Unix Makefiles" /Users/felipe/code/proto3d/EASTL/test /Users/felipe/code/proto3d/EASTL/test/packages/EAStdC /Users/felipe/code/proto3d/EASTL/test/build /Users/felipe/code/proto3d/EASTL/test/build/eastl/test/packages/EAStdC /Users/felipe/code/proto3d/EASTL/test/build/eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/DependInfo.cmake --color=
Scanning dependencies of target EAStdC
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/build.make eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 56
[  1%] Building CXX object eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/source/EAMemory.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl/test/packages/EAStdC && /usr/bin/c++   -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include    -o CMakeFiles/EAStdC.dir/source/EAMemory.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/source/EAMemory.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 57
[  3%] Building CXX object eastl/test/packages/EAStdC/CMakeFiles/EAStdC.dir/source/EASprintf.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl/test/packages/EAStdC && /usr/bin/c++   -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include    -o CMakeFiles/EAStdC.dir/source/EASprintf.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/source/EASprintf.cpp
Linking CXX static library libEAStdC.a
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl/test/packages/EAStdC && /usr/local/Cellar/cmake/3.1.3/bin/cmake -P CMakeFiles/EAStdC.dir/cmake_clean_target.cmake
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl/test/packages/EAStdC && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_link_script CMakeFiles/EAStdC.dir/link.txt --verbose=1
/usr/bin/ar cq libEAStdC.a  CMakeFiles/EAStdC.dir/source/EAMemory.cpp.o CMakeFiles/EAStdC.dir/source/EASprintf.cpp.o
/usr/bin/ranlib libEAStdC.a
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles  56 57
[  3%] Built target EAStdC
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f eastl/CMakeFiles/EASTL.dir/build.make eastl/CMakeFiles/EASTL.dir/depend
cd /Users/felipe/code/proto3d/EASTL/test/build && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_depends "Unix Makefiles" /Users/felipe/code/proto3d/EASTL/test /Users/felipe/code/proto3d/EASTL /Users/felipe/code/proto3d/EASTL/test/build /Users/felipe/code/proto3d/EASTL/test/build/eastl /Users/felipe/code/proto3d/EASTL/test/build/eastl/CMakeFiles/EASTL.dir/DependInfo.cmake --color=
Scanning dependencies of target EASTL
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f eastl/CMakeFiles/EASTL.dir/build.make eastl/CMakeFiles/EASTL.dir/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 1
[  5%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/allocator_eastl.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/allocator_eastl.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/allocator_eastl.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 2
[  6%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/assert.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/assert.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/assert.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 3
[  8%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/fixed_pool.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/fixed_pool.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/fixed_pool.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 4
[ 10%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/hashtable.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/hashtable.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/hashtable.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 5
[ 12%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/intrusive_list.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/intrusive_list.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/intrusive_list.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 6
[ 13%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/numeric_limits.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/numeric_limits.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/numeric_limits.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 7
[ 15%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/red_black_tree.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/red_black_tree.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/red_black_tree.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 8
[ 17%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/string.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/string.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/string.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 9
[ 18%] Building CXX object eastl/CMakeFiles/EASTL.dir/source/thread_support.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTL.dir/source/thread_support.cpp.o -c /Users/felipe/code/proto3d/EASTL/source/thread_support.cpp
Linking CXX static library libEASTL.a
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/local/Cellar/cmake/3.1.3/bin/cmake -P CMakeFiles/EASTL.dir/cmake_clean_target.cmake
cd /Users/felipe/code/proto3d/EASTL/test/build/eastl && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_link_script CMakeFiles/EASTL.dir/link.txt --verbose=1
/usr/bin/ar cq libEASTL.a  CMakeFiles/EASTL.dir/source/allocator_eastl.cpp.o CMakeFiles/EASTL.dir/source/assert.cpp.o CMakeFiles/EASTL.dir/source/fixed_pool.cpp.o CMakeFiles/EASTL.dir/source/hashtable.cpp.o CMakeFiles/EASTL.dir/source/intrusive_list.cpp.o CMakeFiles/EASTL.dir/source/numeric_limits.cpp.o CMakeFiles/EASTL.dir/source/red_black_tree.cpp.o CMakeFiles/EASTL.dir/source/string.cpp.o CMakeFiles/EASTL.dir/source/thread_support.cpp.o
/usr/bin/ranlib libEASTL.a
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles  1 2 3 4 5 6 7 8 9
[ 18%] Built target EASTL
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f packages/EATest/CMakeFiles/EATest.dir/build.make packages/EATest/CMakeFiles/EATest.dir/depend
cd /Users/felipe/code/proto3d/EASTL/test/build && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_depends "Unix Makefiles" /Users/felipe/code/proto3d/EASTL/test /Users/felipe/code/proto3d/EASTL/test/packages/EATest /Users/felipe/code/proto3d/EASTL/test/build /Users/felipe/code/proto3d/EASTL/test/build/packages/EATest /Users/felipe/code/proto3d/EASTL/test/build/packages/EATest/CMakeFiles/EATest.dir/DependInfo.cmake --color=
Scanning dependencies of target EATest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f packages/EATest/CMakeFiles/EATest.dir/build.make packages/EATest/CMakeFiles/EATest.dir/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 58
[ 20%] Building CXX object packages/EATest/CMakeFiles/EATest.dir/source/EATest.cpp.o
cd /Users/felipe/code/proto3d/EASTL/test/build/packages/EATest && /usr/bin/c++   -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -std=c++11 -Wdeprecated -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include    -o CMakeFiles/EATest.dir/source/EATest.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/packages/EATest/source/EATest.cpp
Linking CXX static library libEATest.a
cd /Users/felipe/code/proto3d/EASTL/test/build/packages/EATest && /usr/local/Cellar/cmake/3.1.3/bin/cmake -P CMakeFiles/EATest.dir/cmake_clean_target.cmake
cd /Users/felipe/code/proto3d/EASTL/test/build/packages/EATest && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_link_script CMakeFiles/EATest.dir/link.txt --verbose=1
/usr/bin/ar cq libEATest.a  CMakeFiles/EATest.dir/source/EATest.cpp.o
/usr/bin/ranlib libEATest.a
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles  58
[ 20%] Built target EATest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/EASTLTest.dir/build.make CMakeFiles/EASTLTest.dir/depend
cd /Users/felipe/code/proto3d/EASTL/test/build && /usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_depends "Unix Makefiles" /Users/felipe/code/proto3d/EASTL/test /Users/felipe/code/proto3d/EASTL/test /Users/felipe/code/proto3d/EASTL/test/build /Users/felipe/code/proto3d/EASTL/test/build /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles/EASTLTest.dir/DependInfo.cmake --color=
Scanning dependencies of target EASTLTest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/EASTLTest.dir/build.make CMakeFiles/EASTLTest.dir/build
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 10
[ 22%] Building CXX object CMakeFiles/EASTLTest.dir/source/EASTLTest.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTLTest.dir/source/EASTLTest.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/source/EASTLTest.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 11
[ 24%] Building CXX object CMakeFiles/EASTLTest.dir/source/EASTLTestAllocator.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTLTest.dir/source/EASTLTestAllocator.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/source/EASTLTestAllocator.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 12
[ 25%] Building CXX object CMakeFiles/EASTLTest.dir/source/main.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTLTest.dir/source/main.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/source/main.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 13
[ 27%] Building CXX object CMakeFiles/EASTLTest.dir/source/TestAlgorithm.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTLTest.dir/source/TestAlgorithm.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/source/TestAlgorithm.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 14
[ 29%] Building CXX object CMakeFiles/EASTLTest.dir/source/TestAllocator.cpp.o
/usr/bin/c++   -DEASTL_OPENSOURCE -DEASTL_THREAD_SUPPORT_AVAILABLE=0 -D_CRT_SECURE_NO_WARNINGS -std=c++11 -I/Users/felipe/code/proto3d/EASTL/test/source -I/Users/felipe/code/proto3d/EASTL/include -I/Users/felipe/code/proto3d/EASTL/test/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EABase/include/Common -I/Users/felipe/code/proto3d/EASTL/test/packages/EAAssert/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAMain/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAStdC/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EAThread/include -I/Users/felipe/code/proto3d/EASTL/test/packages/EATest/include    -o CMakeFiles/EASTLTest.dir/source/TestAllocator.cpp.o -c /Users/felipe/code/proto3d/EASTL/test/source/TestAllocator.cpp
/usr/local/Cellar/cmake/3.1.3/bin/cmake -E cmake_progress_report /Users/felipe/code/proto3d/EASTL/test/build/CMakeFiles 15
...........
```