### PR TITLE
Updated the CMake build system to work with Intel's compilers on Unix based systems, including OS X.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ add_library(EASTL ${EASTL_SOURCES})
 # Compiler Flags
 #-------------------------------------------------------------------------------------------
 set_property(TARGET EASTL PROPERTY CXX_STANDARD 11)
+if( UNIX AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fasm-blocks" )
+endif()
 
 #-------------------------------------------------------------------------------------------
 # Include dirs


### PR DESCRIPTION
CMake does not support compiler traits with the Intel compiler (used in the root CMakeLists.txt file for 'set_property(TARGET EASTL PROPERTY CXX_STANDARD 11)'), and the Intel compiler requires an explicit asm-block flag to build. This pull request checks if the build is executing on a Unix-based system with the Intel compiler, and adds flags to enable C++11 and asm-blocks. This enables successful builds on OS X Mavericks and Ubuntu 12.04 with Intel 16.0.1.