### PR TITLE
Close varargs before reassignment with va_copy and after using them

### DIFF
--- a/test/packages/EATest/source/EATest.cpp
+++ b/test/packages/EATest/source/EATest.cpp
@@ -127,6 +127,7 @@ namespace UnitTest
                     if(pBuffer)
                     {
                         #if defined(EA_COMPILER_VA_COPY_REQUIRED)
+                            va_end(arguments);
                             va_copy(arguments, argumentsSaved);
                         #endif
                         EA::StdC::Vsnprintf(pBuffer, nReturnValue + 1, pFormat, arguments);
@@ -138,6 +139,9 @@ namespace UnitTest
                 }
 
                 va_end(arguments);
+                #if defined(EA_COMPILER_VA_COPY_REQUIRED)
+                    va_end(argumentsSaved);
+                #endif
             }
 
             return bExpression ? 0 : 1;
@@ -178,6 +182,7 @@ namespace UnitTest
                     if(pBuffer)
                     {
                         #if defined(EA_COMPILER_VA_COPY_REQUIRED)
+                            va_end(arguments);
                             va_copy(arguments, argumentsSaved);
                         #endif
                         EA::StdC::Vsnprintf(pBuffer, nReturnValue + 1, pFormat, arguments);
@@ -191,6 +196,9 @@ namespace UnitTest
                 IncrementGlobalErrorCount(nErrorCount);
 
                 va_end(arguments);
+                #if defined(EA_COMPILER_VA_COPY_REQUIRED)
+                    va_end(argumentsSaved);
+                #endif
             }
 
             return nErrorCount;


### PR DESCRIPTION
arguments wasn't closed with va_end() before being reassigned with va_copy() and argumentsSaved wasn't closed at all at the end.