### PR TITLE
Revert "Allow libs of different configs to be installed in parallel"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(EASTL EABase)
 #-------------------------------------------------------------------------------------------
 # Installation
 #-------------------------------------------------------------------------------------------
-install(TARGETS EASTL DESTINATION lib/\${BUILD_TYPE})
+install(TARGETS EASTL DESTINATION lib)
 install(DIRECTORY include/EASTL DESTINATION include)
 install(DIRECTORY test/packages/EABase/include/Common/EABase DESTINATION include)
 


### PR DESCRIPTION
Reverts electronicarts/EASTL#38
Reasons:
- The code is untested.
- It doesn't work.
- It would break on Linux if it did work.