### PR TITLE
Fixed issue where cmake (3.2.2) does not understand its own tests 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 #-------------------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.1)
 project(EASTL CXX)
+enable_language(C)
 
 #-------------------------------------------------------------------------------------------
 # Options
@@ -83,4 +84,3 @@ target_link_libraries(EASTL EABase)
 install(TARGETS EASTL DESTINATION lib)
 install(DIRECTORY include/EASTL DESTINATION include)
 install(DIRECTORY test/packages/EABase/include/Common/EABase DESTINATION include)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@
 # Copyright (C) Electronic Arts Inc.  All rights reserved.
 #-------------------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.1)
-project(EASTL CXX)
-enable_language(C)
+project(EASTL)
 
 #-------------------------------------------------------------------------------------------
 # Options


### PR DESCRIPTION
CMake Error at /usr/local/share/cmake-3.2/Modules/CheckIncludeFiles.cmake:74 (try_compile):
  Unknown extension ".c" for file

Adding the C language to the "project" command causes other problems.
The solution was to enable the "C" language explicitly in CMakeLists.txt
    enable_language(C)

