### PR TITLE
Fix linking error on windows when not using msvc.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,7 +52,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 set(EASTLTest_Libraries EASTL EATest)
-if((NOT APPLE) AND (NOT MSVC))
+if((NOT APPLE) AND (NOT WIN32))
 	target_link_libraries(EASTLTest ${EASTLTest_Libraries} Threads::Threads rt)
 else()
 	target_link_libraries(EASTLTest ${EASTLTest_Libraries} Threads::Threads)


### PR DESCRIPTION
No compiler that I know of on Windows has librt, as such we shouldn't include it.
Verified working.