### PR TITLE
Changed insertion_sort so wont decrement an iterator too far.

### DIFF
--- a/include/EASTL/InsertionSortDriver.cpp
+++ b/include/EASTL/InsertionSortDriver.cpp
@@ -1,0 +1,178 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <time.h>
+#include <assert.h>
+typedef unsigned long ulong;
+typedef int32_t i32;
+
+#ifdef EASTL_VALIDATE_COMPARE
+    #undef EASTL_VALIDATE_COMPARE
+    #define EASTL_VALIDATE_COMPARE(x) ((void)0)
+#endif // EASTL_VALIDATE_COMPARE
+
+#include <EASTL/sort.h>
+
+const auto Less=[](i32 a, i32 b){ return a<b; };
+
+enum:size_t{OneMil=10000000u};
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <wincrypt.h>
+bool FillRandom(void* a, size_t bytes)
+{
+    HCRYPTPROV   hCryptProv;
+
+    if (CryptAcquireContext(&hCryptProv, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+    {
+        const bool ret=CryptGenRandom(hCryptProv, bytes, static_cast<BYTE*>(a));
+
+        puts(ret ? "Random sequence successfully generated" : "Error during CryptGenRandom");
+
+        return CryptReleaseContext(hCryptProv, 0) ? (puts("Crypt handle released"), ret) : (puts("Crypt handle failed to release"), false);
+    }
+    else
+    {
+        puts("A cryptographic service handle could not be acquired");
+        return false;
+    }
+}
+#else
+#include <fcntl.h>
+#include <unistd.h>
+bool FillRandom(void* a, size_t bytes)
+{
+    const int fd=open("/dev/random", O_RDONLY);
+    if (fd>=0)
+    {
+        const ptrdiff_t nRead=read(fd, a, bytes);
+        bool ret = (nRead<0 || size_t(nRead)<bytes) ? (perror("read"), false) : true;
+        if (close(fd)!=0) perror("close"), ret=false;
+        return ret;
+    }
+    else
+    {
+        perror("open() failed on /dev/random");
+        return false;
+    }
+}
+#endif//WIN32
+
+void TestNewInsertionSort(const int NumTests=30)
+{
+    enum:size_t{SmallArraySize=20u, N=OneMil};
+
+    static i32 data[N];
+
+    FILE* TempDataFile=tmpfile();
+    if (TempDataFile==NULL)
+    {
+        perror("couldn't create temp file");
+        return;
+    }
+
+    if (!FillRandom(data, sizeof data)) { return; }
+    if (fwrite(data, 4, N, TempDataFile)!=N) { perror("fwrite"); return; }
+
+    int observe=0;
+    clock_t start, stop, oldSum=0, newSum=0;
+    i32* it=NULL;
+    for (int loops=NumTests; loops-- > 0; )
+    {
+        //testing current version
+        rewind(TempDataFile);
+        if (fread(data, 4, N, TempDataFile)!=N) { perror("fread"); return; }
+
+        start=clock();
+        //test many small arrays instead of a big one, or will take a while
+        it=data;
+        for (size_t j=SmallArraySize; j<=N; it+=SmallArraySize, j+=SmallArraySize)
+        {
+            eastl::insertion_sort(it, data+j);
+            //assert(eastl::is_sorted(it, data+j));
+            observe ^= *it;
+        }
+        stop=clock();
+        oldSum += stop-start;
+
+        //testing new version
+        rewind(TempDataFile);
+        if (fread(data, 4, N, TempDataFile)!=N) { perror("fread"); return; }
+
+        start=clock();
+        //test many small arrays instead of a big one, or will take a while
+        it=data;
+        for (size_t j=SmallArraySize; j<=N; it+=SmallArraySize, j+=SmallArraySize)
+        {
+            eastl::insertion_sort_new(it, data+j);
+            //assert(eastl::is_sorted(it, data+j));
+            observe ^= *it;
+        }
+        stop=clock();
+        newSum += stop-start;
+    }
+
+    printf("Old isort took %ld clocks.\n", (long)oldSum);
+    printf("New isort took %ld clocks.\n", (long)newSum);
+    printf("something observable: %d\n", observe);
+    getchar();
+}
+
+//lots of repetition here...
+void TestNewMergeSortBuffer(const int NumTests=30)
+{
+    enum:size_t{N=OneMil};
+
+    static i32 data[N];
+    static i32 buf_full[N];
+    static i32 buf_half[N/2u];//new version needs half the space
+
+    FILE* TempDataFile=tmpfile();
+    if (TempDataFile==NULL)
+    {
+        perror("couldn't create temp file");
+        return;
+    }
+
+    if (!FillRandom(data, sizeof data)) { return; }
+    if (fwrite(data, 4, N, TempDataFile)!=N) { perror("fwrite"); return; }
+
+    int observe=0;
+    clock_t start, stop, oldSum=0, newSum=0;
+    for (int loops=NumTests; loops-- > 0; )
+    {
+        //testing current version
+        rewind(TempDataFile);
+        if (fread(data, 4, N, TempDataFile)!=N) { perror("fread"); return; }
+
+        start=clock();
+        eastl::merge_sort_buffer(data, data+N, buf_full, Less);
+        stop=clock();
+        oldSum += stop-start;
+        //assert(eastl::is_sorted(data, data+N));
+
+        //testing new version
+        rewind(TempDataFile);
+        if (fread(data, 4, N, TempDataFile)!=N) { perror("fread"); return; }
+
+        start=clock();
+        eastl::merge_sort_buffer_new(data, N, buf_half, Less);
+        stop=clock();
+        newSum += stop-start;
+        //assert(eastl::is_sorted(data, data+N));
+    }
+
+    printf("Old msort_buf took %ld clocks.\n", (long)oldSum);
+    printf("New msort_buf took %ld clocks.\n", (long)newSum);
+    printf("something observable: %d\n", observe);
+    getchar();
+}
+
+int main()
+{
+    //TestNewInsertionSort();
+    TestNewMergeSortBuffer(8);
+
+    return 0;
+}

--- a/include/EASTL/InsertionSortDriver.cpp
+++ b/include/EASTL/InsertionSortDriver.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <time.h>
 #include <assert.h>
@@ -140,20 +141,34 @@ void TestInsertionSorts(i32* a, size_t n, size_t smallArrayN=20)
 }
 
 const char* const DataFileName="rand_0.dat";
-enum:size_t{N=TenMil};//ten million
+enum:size_t{N=TenMil};
+/*
+This is probably a really clunky way to do things,
+but I'm concerned that running sort B right after sort A
+might give sort B some kind of advantage, and this is something
+that addresses it I think.
 
-#if 1//test insertion sorts
+The program just makes an executable that times 1 function,
+and I run it a few times, than make some edits to the cpp file to test the other, build and repeat.
+
+First, a file needs to be made so the same data is used across executables.
+
+To use this, alternate the if directives below, and comment out the other functions in
+TestInsertionSorts so theres only one
+*/
+
+#if 1//test insertion sorts or create a file, change to test merge sorts
 int main()
 {
     static i32 a[N];
 
-    #if 0//need to create a file
+    #if 1//create a file
     if (!FillRandom(a, sizeof a)) return 1;
     if (!Write(DataFileName, a, sizeof a)) return 1;
-    #else
+    #else//test insertion sorts
     if (!Read(DataFileName, a, sizeof a)) return 1;
 
-    TestInsertionSorts(a, N);//need to go in and comment out all but 1
+    TestInsertionSorts(a, N);//need to go in and comment out all but 1 that want to test
     #endif
 
     return 0;

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -205,77 +205,144 @@ namespace eastl
 
 
 
-	/// insertion_sort
-	///
-	/// Since insertion_sort requires that the data be addressed with a BidirectionalIterator and 
-	/// not the more flexible RandomAccessIterator, we implement the sort by doing a for loop within
-	/// a for loop. If we were to specialize this for a RandomAccessIterator, we could replace the
-	/// inner for loop with a call to upper_bound, which would be faster.
-	///
-	template <typename BidirectionalIterator, typename StrictWeakOrdering>
-	void insertion_sort(BidirectionalIterator first, BidirectionalIterator last, StrictWeakOrdering compare)
+	/* Insertion Sort
+	 *
+	 * An in-place and stable sorting algorithm that is fast for small arrays,
+	 * making it useful in algorithms like Quick Sort, Merge Sort, most-significant-
+	 * digit Radix Sorts, and Quick Select, which divide their inputs into smaller (semi)sorted segments.
+	 *
+	 * An improvement for larger inputs would be to use upper_bound to find the insertion position,
+	 * followed by memmove, but it will still be slow for large inputs, and not worth it for small ones.
+	 *
+	 * If base[-1] is a sentinel the short-circuit can be removed, but this is a general purpose version.
+	 */
+	
+	//compare functor version
+	template<class Iter, class Compare>//Bidirectional Iterator, though something like a list shouldn't use this
+	void insertion_sort(Iter const base, Iter const past, Compare cmp)
 	{
-		typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
-
-		if(first != last) // if the range is non-empty...
-		{
-			BidirectionalIterator iCurrent, iNext, iSorted = first;
-
-			for(++iSorted; iSorted != last; ++iSorted)
-			{
-				const value_type temp(*iSorted);
-
-				iNext = iCurrent = iSorted;
-
-				// Note: The following loop has a problem: it can decrement iCurrent to before 'first'.
-				// It doesn't dereference the iterator, but std STL disallows that operation. This isn't 
-				// a problem for EASTL containers and ranges, as they support a single decrement of first,
-				// but std STL iterators may have a problem with it. Dinkumware STL, for example, will assert.
-				// To do: Fix this loop to not decrement like so.
-				for(--iCurrent; (iNext != first) && compare(temp, *iCurrent); --iNext, --iCurrent)
-				{
-					EASTL_VALIDATE_COMPARE(!compare(*iCurrent, temp)); // Validate that the compare function is sane.
-					*iNext = *iCurrent;
-				}
-
-				*iNext = temp;
-			}
-		}
-	} // insertion_sort
-
-
-
-	template <typename BidirectionalIterator>
-	void insertion_sort(BidirectionalIterator first, BidirectionalIterator last)
+	    typedef typename eastl::iterator_traits<Iter>::value_type value_type;
+	
+	    if (base!=past)
+	    {   //this could perhaps be written more idiomatic: for (T *left=base, *sorted=base+1; sorted!=past; left=sorted++)
+	        for (Iter left=base, sorted=base; ++sorted!=past; left=sorted)
+	        {
+	            if (cmp(*sorted, *left))
+	            {
+	                const value_type val=*sorted;//should we care about doing moves instead?
+	                Iter right=sorted;
+	
+	                do
+	                {
+	                    EASTL_VALIDATE_COMPARE(!cmp(*left, val));//validate cmp is sane by checking other way
+	                    *right=*left;
+	                }while ((right=left)!=base && cmp(val, *--left));
+	
+	                *right=val;
+	            }
+	        }//outer loop
+	    }//non-empty range
+	}//insertion_sort (Compare)
+	
+	//default less-than version
+	template<class Iter>//Bidirectional Iterator, though something like a list shouldn't use this
+	void insertion_sort(Iter const base, Iter const past)
 	{
-		typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
+	    typedef typename eastl::iterator_traits<Iter>::value_type value_type;
+	
+	    if (base!=past)
+	    {   //this could perhaps be written more idiomatic: for (T *left=base, *sorted=base+1; sorted!=past; left=sorted++)
+	        for (Iter left=base, sorted=base; ++sorted!=past; left=sorted)
+	        {
+	            if (*sorted < *left)
+	            {
+	                const value_type val=*sorted;//should we care about doing moves instead?
+	                Iter right=sorted;
+	
+	                do
+	                {
+	                    EASTL_VALIDATE_COMPARE(!(*left<val));//validate cmp is sane by checking other way
+	                    *right=*left;
+	                }while ((right=left)!=base && val<*--left);
+	
+	                *right=val;
+	            }
+	        }//outer loop
+	    }//non-empty range
+	}//insertion_sort
 
-		if(first != last)
-		{
-			BidirectionalIterator iCurrent, iNext, iSorted = first;
+#if 0
+/* This following Merge Sort or something similar is worth considering compared to the current version.
 
-			for(++iSorted; iSorted != last; ++iSorted)
-			{
-				const value_type temp(*iSorted);
+First, the buffer only needs a length of half the data, not the full length as it does now.
+Second, it starts by using Insertion Sort on small arrays, which noticeably improves the performance. The full sort is still stable.
 
-				iNext = iCurrent = iSorted;
+In trying to achieve minimal copying, it makes more than 2 recursive calls, as does the current one, but 3 instead of 4.
+Originally I thought of doing 4, but I think three is simpler and when I thought of doing 4, the buffer length might need to be a little over n/2.
 
-				// Note: The following loop has a problem: it can decrement iCurrent to before 'first'.
-				// It doesn't dereference the iterator, but std STL disallows that operation. This isn't 
-				// a problem for EASTL containers and ranges, as they support a single decrement of first,
-				// but std STL iterators may have a problem with it. Dinkumware STL, for example, will assert.
-				// To do: Fix this loop to not decrement like so.
-				for(--iCurrent; (iNext != first) && (temp < *iCurrent); --iNext, --iCurrent)
-				{
-					EASTL_VALIDATE_COMPARE(!(*iCurrent < temp)); // Validate that the compare function is sane.
-					*iNext = *iCurrent;
-				}
+With three it may start out by Insertion Sorting varying length chunks. Though I'm not sure about the implications of this.
+Lets say a small array is <=24 in length and should be Insertion Sorted:
+- if the input array is of size 25, with 3 calls we do 3 insertion sorts on lengths 6, 6 and 13;
+ with 4 calls there would instead be 4 insertion sorts of 6, 6, 6, 7.
+- if the input array is of size 50, with 3 calls we do 5 insertion sorts: 12, 13, (6,6), 13;
+ with 4 calls instead would do 4 of maybe: 12, 12, 12, 14.
 
-				*iNext = temp;
-			}
-		}
-	} // insertion_sort
+Also, in the final merge, if the left range(the buffer containing the merged 2 first quarters) is exhausted first,
+there is nothing left to copy, which is another potential speedup.
+*/
 
+/*
+ * FinishingMerge (internal function)
+ * like a normal merge, but nothing left is copied if the left range is exhausted first
+ *
+ * assumes both ranges non-empty, since caller is msort which checks if the array is large enough when checking
+ * if it should instead use insertion sort
+ *
+ * also like mentioned in insertion_sort, should we care about doing moves instead?
+ */
+template<class BufIt, class DataIt, class Compare>
+void FinishingMerge(BufIt l, BufIt const lEnd, DataIt r, DataIt const rEnd, DataIt dest, Compare cmp)
+{
+    for (;;)//assume both ranges not empty
+    {
+        if (cmp(*r, *l))
+        {
+            *dest++ = *r++;
+            if (r==rEnd)
+                break;//copy remaining left
+        }
+        else//equal elements first taken from left for stability
+        {
+            *dest++ = *l++;
+            if (l==lEnd)
+                return;//nothing left to copy
+        }
+    }
+
+    eastl::copy(l, lEnd, dest);
+}
+
+template<class DataIter, class BufIter, class Compare>
+void merge_sort_buffer(DataIter data, size_t n, BufIter buf, Compare cmp)//n is length of data, buffer must be at least of length n/2
+{
+    if (n>=25u)
+    {
+        const size_t nHalf=n>>1u, nFourth=n>>2u;
+        DataIter const iMid=data+nHalf, iQuad=data+nFourth;
+        //sort first and second quarters of data, will be merged into buffer
+        eastl::merge_sort_buffer(data, nFourth, buf, cmp);
+        eastl::merge_sort_buffer(iQuad, nHalf-nFourth, buf, cmp);
+        //sort right Half of data
+        eastl::merge_sort_buffer(iMid, n-nHalf, buf, cmp);
+        //merge first 2 quarters into buffer.
+        eastl::merge(data, iQuad, iQuad, iMid, buf, cmp);
+        //the following is like a normal merge, but nothing remains to be copied if the left range is exhausted first
+        eastl::FinishingMerge(buf, buf+nHalf, iMid, data+n, data, cmp);
+    }
+    else
+        eastl::insertion_sort(data, data+n, cmp);
+}
+#endif
 
 	#if 0 /*
 	// STLPort-like variation of insertion_sort. Doesn't seem to run quite as fast for small runs.

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -202,10 +202,83 @@ namespace eastl
 		return eastl::merge<InputIterator1, InputIterator2, OutputIterator, Less>
 						   (first1, last1, first2, last2, result, Less());
 	}
+	
+	
+	
+	
+	/// insertion_sort
+	///
+	/// Since insertion_sort requires that the data be addressed with a BidirectionalIterator and
+	/// not the more flexible RandomAccessIterator, we implement the sort by doing a for loop within
+	/// a for loop. If we were to specialize this for a RandomAccessIterator, we could replace the
+	/// inner for loop with a call to upper_bound, which would be faster.
+	///
+	template <typename BidirectionalIterator, typename StrictWeakOrdering>
+	void insertion_sort(BidirectionalIterator first, BidirectionalIterator last, StrictWeakOrdering compare)
+	{
+	    typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
+	
+	    if(first != last) // if the range is non-empty...
+	    {
+	        BidirectionalIterator iCurrent, iNext, iSorted = first;
+	
+	        for(++iSorted; iSorted != last; ++iSorted)
+	        {
+	            const value_type temp(*iSorted);
+	
+	            iNext = iCurrent = iSorted;
+	
+	            // Note: The following loop has a problem: it can decrement iCurrent to before 'first'.
+	            // It doesn't dereference the iterator, but std STL disallows that operation. This isn't
+	            // a problem for EASTL containers and ranges, as they support a single decrement of first,
+	            // but std STL iterators may have a problem with it. Dinkumware STL, for example, will assert.
+	            // To do: Fix this loop to not decrement like so.
+	            for(--iCurrent; (iNext != first) && compare(temp, *iCurrent); --iNext, --iCurrent)
+	            {
+	                EASTL_VALIDATE_COMPARE(!compare(*iCurrent, temp)); // Validate that the compare function is sane.
+	                *iNext = *iCurrent;
+	            }
+	
+	            *iNext = temp;
+	        }
+	    }
+	} // insertion_sort
+	
+	
+	
+	template <typename BidirectionalIterator>
+	void insertion_sort(BidirectionalIterator first, BidirectionalIterator last)
+	{
+	    typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
+	
+	    if(first != last)
+	    {
+	        BidirectionalIterator iCurrent, iNext, iSorted = first;
+	
+	        for(++iSorted; iSorted != last; ++iSorted)
+	        {
+	            const value_type temp(*iSorted);
+	
+	            iNext = iCurrent = iSorted;
+	
+	            // Note: The following loop has a problem: it can decrement iCurrent to before 'first'.
+	            // It doesn't dereference the iterator, but std STL disallows that operation. This isn't
+	            // a problem for EASTL containers and ranges, as they support a single decrement of first,
+	            // but std STL iterators may have a problem with it. Dinkumware STL, for example, will assert.
+	            // To do: Fix this loop to not decrement like so.
+	            for(--iCurrent; (iNext != first) && (temp < *iCurrent); --iNext, --iCurrent)
+	            {
+	                EASTL_VALIDATE_COMPARE(!(*iCurrent < temp)); // Validate that the compare function is sane.
+	                *iNext = *iCurrent;
+	            }
+	
+	            *iNext = temp;
+	        }
+	    }
+	} // insertion_sort
 
-
-
-	//Insertion Sort
+	
+	//Insertion Sort (new)
 	//An in-place and stable sorting algorithm that is fast for small arrays.
 	//The following and the default less than compare version are general purpose.
 	

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -279,9 +279,16 @@ namespace eastl
 	
 	
 	
-	///Insertion Sort (new)
-	///An in-place and stable sorting algorithm that is fast for small arrays.
-	///The following and the default less than compare version are general purpose.
+	///modified insertion sort that fixes the decrement problem
+	///
+	///also it seems that:
+	///for (...; ...; iRight=iLeft--)
+	///can be slighlty faster than:
+	///for (...; ...; --iLeft, --iRight)
+	///
+	///inner loop changed(after above change)
+	///from this:	for(--iLeft; iRight!=first && temp<*iLeft  ; iRight=iLeft--){}
+	///  to this:	for(       ; iRight!=first && temp<*--iLeft; iRight=iLeft  ){}
 	
 	//compare functor version
 	template<typename BidirectionalIterator, typename Compare>//Bidirectional Iterator, though something like a list shouldn't use this
@@ -289,14 +296,14 @@ namespace eastl
 	{
 	    typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
 	
-	    if (first!=last)
+	    if (first!=last)//if range not empty
 	    {
 	        BidirectionalIterator iLeft, iRight, iSorted=first;
-	        while (++iSorted!=last)
+	        for (++iSorted; iSorted!=last; ++iSorted)//an array of length 1 is already sorted
 	        {
-	            const value_type temp(*iSorted);//should we care about doing moves instead?
+	            const value_type temp(*iSorted);
 	
-	            for (iLeft=iRight=iSorted; iRight!=first && cmp(temp, *--iLeft); --iRight)
+	            for (iLeft=iRight=iSorted; iRight!=first && cmp(temp, *--iLeft); iRight=iLeft)
 	            {
 	                EASTL_VALIDATE_COMPARE(!cmp(*iLeft, temp));//validate cmp is sane by checking other way
 	                *iRight=*iLeft;
@@ -305,22 +312,21 @@ namespace eastl
 	            *iRight=temp;
 	        }//outer loop
 	    }
-	}//insertion_sort (Compare
+	}//insertion_sort (Compare)
 	
-	//default less-than version
-	template<typename BidirectionalIterator>//Bidirectional Iterator, though something like a list shouldn't use this
+	template<typename BidirectionalIterator>//default less-than version
 	void insertion_sort_new(BidirectionalIterator const first, BidirectionalIterator const last)
 	{
 	    typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
 	
-	    if (first!=last)
+	    if (first!=last)//if range not empty
 	    {
 	        BidirectionalIterator iLeft, iRight, iSorted=first;
-	        while (++iSorted!=last)
+	        for (++iSorted; iSorted!=last; ++iSorted)//an array of length 1 is already sorted
 	        {
-	            const value_type temp(*iSorted);//should we care about doing moves instead?
+	            const value_type temp(*iSorted);
 	
-	            for (iLeft=iRight=iSorted; iRight!=first && temp<*--iLeft; --iRight)
+	            for (iLeft=iRight=iSorted; iRight!=first && temp<*--iLeft; iRight=iLeft)
 	            {
 	                EASTL_VALIDATE_COMPARE(!(*iLeft<temp));//validate cmp is sane by checking other way
 	                *iRight=*iLeft;

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -276,11 +276,12 @@ namespace eastl
 	        }
 	    }
 	} // insertion_sort
-
 	
-	//Insertion Sort (new)
-	//An in-place and stable sorting algorithm that is fast for small arrays.
-	//The following and the default less than compare version are general purpose.
+	
+	
+	///Insertion Sort (new)
+	///An in-place and stable sorting algorithm that is fast for small arrays.
+	///The following and the default less than compare version are general purpose.
 	
 	//compare functor version
 	template<typename BidirectionalIterator, typename Compare>//Bidirectional Iterator, though something like a list shouldn't use this
@@ -290,25 +291,21 @@ namespace eastl
 	
 	    if (first!=last)
 	    {
-	        BidirectionalIterator iLeft=first, iSorted=first;
-	        for (++iSorted; iSorted!=last; iLeft=iSorted, ++iSorted)
+	        BidirectionalIterator iLeft, iRight, iSorted=first;
+	        while (++iSorted!=last)
 	        {
-	            if (cmp(*iSorted, *iLeft))
+	            const value_type temp(*iSorted);//should we care about doing moves instead?
+	
+	            for (iLeft=iRight=iSorted; iRight!=first && cmp(temp, *--iLeft); --iRight)
 	            {
-	                const value_type temp(*iSorted);//should we care about doing moves instead?
-	                BidirectionalIterator iRight=iSorted;
-	
-	                do
-	                {
-	                    EASTL_VALIDATE_COMPARE(!cmp(*iLeft, temp));//validate cmp is sane by checking other way
-	                    *iRight=*iLeft;
-	                }while ((iRight=iLeft)!=first && cmp(temp, *--iLeft));
-	
-	                *iRight=temp;
+	                EASTL_VALIDATE_COMPARE(!cmp(*iLeft, temp));//validate cmp is sane by checking other way
+	                *iRight=*iLeft;
 	            }
-	        }//outer for loop
+	
+	            *iRight=temp;
+	        }//outer loop
 	    }
-	}//insertion_sort (Compare)
+	}//insertion_sort (Compare
 	
 	//default less-than version
 	template<typename BidirectionalIterator>//Bidirectional Iterator, though something like a list shouldn't use this
@@ -318,29 +315,25 @@ namespace eastl
 	
 	    if (first!=last)
 	    {
-	        BidirectionalIterator iLeft=first, iSorted=first;
-	        for (++iSorted; iSorted!=last; iLeft=iSorted, ++iSorted)
+	        BidirectionalIterator iLeft, iRight, iSorted=first;
+	        while (++iSorted!=last)
 	        {
-	            if (*iSorted < *iLeft)
+	            const value_type temp(*iSorted);//should we care about doing moves instead?
+	
+	            for (iLeft=iRight=iSorted; iRight!=first && temp<*--iLeft; --iRight)
 	            {
-	                const value_type temp(*iSorted);//should we care about doing moves instead?
-	                BidirectionalIterator iRight=iSorted;
-	
-	                do
-	                {
-	                    EASTL_VALIDATE_COMPARE(!(*iLeft < temp));//validate cmp is sane by checking other way
-	                    *iRight=*iLeft;
-	                }while ((iRight=iLeft)!=first && temp<*--iLeft);
-	
-	                *iRight=temp;
+	                EASTL_VALIDATE_COMPARE(!(*iLeft<temp));//validate cmp is sane by checking other way
+	                *iRight=*iLeft;
 	            }
-	        }//outer for loop
+	
+	            *iRight=temp;
+	        }//outer loop
 	    }
 	}//insertion_sort (less than)
 	
-	//This following Merge Sort or something similar is worth considering compared to the current version.
-	//First, the buffer only needs a length of half the data, not the full length as it does now.
-	//Second, it starts by using Insertion Sort on small arrays, which noticeably improves the performance. The full sort is still stable.
+	///This following Merge Sort or something similar is worth considering compared to the current version.
+	///First, the buffer only needs a length of half the data, not the full length as it does now.
+	///Second, it starts by using Insertion Sort on small arrays, which noticeably improves the performance. The full sort is still stable.
 	
 	//the following is like a normal merge, but nothing remains to be copied if the left range is exhausted first
 	//this is an internal helper and expects both input ranges are not empty


### PR DESCRIPTION
Modified the two versions of insertion_sort so that they wont decrement a pointer to a potentially undefined/invalid state.

Also, though it might not get used much,  I left a new version of merge_sort/stable_sort in comments as a proposal.
It only needs the buffer to be at least half the input size, instead of equal to it, and it seems to be a little faster from some testing I did.