### PR TITLE
Hack to avoid warning on MSVC

### DIFF
--- a/include/EASTL/memory.h
+++ b/include/EASTL/memory.h
@@ -1227,6 +1227,7 @@ namespace eastl
 	template <typename T>
 	inline void destruct(T* p)
 	{
+		(void)p;
 		p->~T();
 	}
 

--- a/include/EASTL/memory.h
+++ b/include/EASTL/memory.h
@@ -1227,7 +1227,10 @@ namespace eastl
 	template <typename T>
 	inline void destruct(T* p)
 	{
-		(void)p;
+		// https://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k(C4100)&rd=true
+		// "C4100 can also be issued when code calls a destructor on a otherwise unreferenced parameter
+		//  of primitive type. This is a limitation of the Visual C++ compiler."
+		EA_UNUSED(p);
 		p->~T();
 	}
 


### PR DESCRIPTION
MSVC (at least 2013) gives a warning if you store a type with an auto generated destructor in some containers (e.g. vector_set) claiming p is unreferenced. This is clearly a problem from their side but this small change ensures that the code compiles.