### PR TITLE
Fix aliasing issues with intrusive_list.

### DIFF
--- a/include/EASTL/intrusive_list.h
+++ b/include/EASTL/intrusive_list.h
@@ -791,8 +791,8 @@ namespace eastl
 				EASTL_FAIL_MSG("intrusive_list::insert(): element already on a list.");
 		#endif
 
-		node_type& next = *const_cast<node_type*>(pos.mpNode);
-		node_type& prev = *static_cast<node_type*>(next.mpPrev);
+		intrusive_list_node& next = *const_cast<node_type*>(pos.mpNode);
+		intrusive_list_node& prev = *static_cast<node_type*>(next.mpPrev);
 		prev.mpNext = next.mpPrev = &x;
 		x.mpPrev    = &prev;
 		x.mpNext    = &next;
@@ -805,8 +805,8 @@ namespace eastl
 	inline typename intrusive_list<T>::iterator
 	intrusive_list<T>::erase(const_iterator pos)
 	{
-		node_type& prev = *static_cast<node_type*>(pos.mpNode->mpPrev);
-		node_type& next = *static_cast<node_type*>(pos.mpNode->mpNext);
+		intrusive_list_node& prev = *static_cast<node_type*>(pos.mpNode->mpPrev);
+		intrusive_list_node& next = *static_cast<node_type*>(pos.mpNode->mpNext);
 		prev.mpNext = &next;
 		next.mpPrev = &prev;
 
@@ -815,7 +815,7 @@ namespace eastl
 			ii.mpNode->mpPrev = ii.mpNode->mpNext = NULL;
 		#endif
 
-		return iterator(&next);
+		return iterator(static_cast<node_type*>(&next));
 	}
 
 
@@ -823,8 +823,8 @@ namespace eastl
 	inline typename intrusive_list<T>::iterator
 	intrusive_list<T>::erase(const_iterator first, const_iterator last)
 	{
-		node_type& prev = *static_cast<node_type*>(first.mpNode->mpPrev);
-		node_type& next = *const_cast<node_type*>(last.mpNode);
+		intrusive_list_node& prev = *static_cast<node_type*>(first.mpNode->mpPrev);
+		intrusive_list_node& next = *const_cast<node_type*>(last.mpNode);
 
 		#if EASTL_VALIDATE_INTRUSIVE_LIST
 			// need to clear out all the next/prev pointers in the elements;
@@ -929,10 +929,10 @@ namespace eastl
 		// Note: &x == this is prohibited, so self-insertion is not a problem.
 		if(x.mAnchor.mpNext != &x.mAnchor) // If the list 'x' isn't empty...
 		{
-			node_type& next       = *const_cast<node_type*>(pos.mpNode);
-			node_type& prev       = *static_cast<node_type*>(next.mpPrev);
-			node_type& insertPrev = *static_cast<node_type*>(x.mAnchor.mpNext);
-			node_type& insertNext = *static_cast<node_type*>(x.mAnchor.mpPrev);
+			intrusive_list_node& next       = *const_cast<node_type*>(pos.mpNode);
+			intrusive_list_node& prev       = *static_cast<node_type*>(next.mpPrev);
+			intrusive_list_node& insertPrev = *static_cast<node_type*>(x.mAnchor.mpNext);
+			intrusive_list_node& insertNext = *static_cast<node_type*>(x.mAnchor.mpPrev);
 
 			prev.mpNext       = &insertPrev;
 			insertPrev.mpPrev = &prev;
@@ -983,16 +983,16 @@ namespace eastl
 		// Note: &x == this is prohibited, so self-insertion is not a problem.
 		if(first != last)
 		{
-			node_type& insertPrev = *const_cast<node_type*>(first.mpNode);
-			node_type& insertNext = *static_cast<node_type*>(last.mpNode->mpPrev);
+			intrusive_list_node& insertPrev = *const_cast<node_type*>(first.mpNode);
+			intrusive_list_node& insertNext = *static_cast<node_type*>(last.mpNode->mpPrev);
 
 			// remove from old list
 			insertNext.mpNext->mpPrev = insertPrev.mpPrev;
 			insertPrev.mpPrev->mpNext = insertNext.mpNext;
 
 			// insert into this list
-			node_type& next = *const_cast<node_type*>(pos.mpNode);
-			node_type& prev = *static_cast<node_type*>(next.mpPrev);
+			intrusive_list_node& next = *const_cast<node_type*>(pos.mpNode);
+			intrusive_list_node& prev = *static_cast<node_type*>(next.mpPrev);
 
 			prev.mpNext       = &insertPrev;
 			insertPrev.mpPrev = &prev;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,14 +20,6 @@ include_directories(source "../include")
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/../scripts/CMake")
 include(CommonCppFlags)
 
-# TODO: Tests fail to pass on mingw-w64 gcc 6 without strict aliasing disabled.
-# The problem is likely a bug in the compiler that causes it to ignore EASTL_MAY_ALIAS
-# on derived classes that are marked with EASTL_MAY_ALIAS.
-# Needs investigating.
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND MINGW)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
-endif()
-
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pointer-bool-conversion -Wno-unknown-warning-option")
 endif()


### PR DESCRIPTION
This _should_ fix the aliasing issues with intrusive_list on GCC that are seen in release mode. Now all node_types are stored in intrusive_list_nodes, allowing the compiler to pickup on the EASTL_MAY_ALIAS attribute/directive.
