### PR TITLE
Update is_assignable to be well-defined on MSVC 2013+

### DIFF
--- a/include/EASTL/internal/type_pod.h
+++ b/include/EASTL/internal/type_pod.h
@@ -1294,7 +1294,7 @@ namespace eastl
 	//
 	///////////////////////////////////////////////////////////////////////
 
-	#if (defined(EA_COMPILER_NO_DECLTYPE) && !EASTL_TYPE_TRAIT_declval_CONFORMANCE) || defined(_MSC_VER) // VS2012 mis-compiles the conforming code below and so must be placed here.
+	#if (defined(EA_COMPILER_NO_DECLTYPE) && !EASTL_TYPE_TRAIT_declval_CONFORMANCE) || (defined(_MSC_VER) && _MSC_VER <= 1800) // VS2012 mis-compiles the conforming code below and so must be placed here.
 		#define EASTL_TYPE_TRAIT_is_assignable_CONFORMANCE 0
 
 		// It's impossible to do this correctly without declval or some other compiler help.
@@ -1667,7 +1667,7 @@ namespace eastl
 	// For a complete type T and given 
 	//     template <class U>
 	//     struct test { U u; };
-	// test<T>::˜test() is not deleted (C++11 "= delete").
+	// test<T>::ï¿½test() is not deleted (C++11 "= delete").
 	// T shall be a complete type, (possibly cv-qualified) void, or an array of unknown bound.
 	//
 	///////////////////////////////////////////////////////////////////////

--- a/include/EASTL/internal/type_pod.h
+++ b/include/EASTL/internal/type_pod.h
@@ -1667,7 +1667,7 @@ namespace eastl
 	// For a complete type T and given 
 	//     template <class U>
 	//     struct test { U u; };
-	// test<T>::�test() is not deleted (C++11 "= delete").
+	// test<T>::test() is not deleted (C++11 "= delete").
 	// T shall be a complete type, (possibly cv-qualified) void, or an array of unknown bound.
 	//
 	///////////////////////////////////////////////////////////////////////

--- a/test/source/TestTypeTraits.cpp
+++ b/test/source/TestTypeTraits.cpp
@@ -1006,12 +1006,12 @@ int TestTypeTraits()
 	static_assert((eastl::is_assignable<char*, const char*>::value     == false),  "is_assignable failure");
 	static_assert((eastl::is_assignable<PodA, PodB*>::value            == false),  "is_assignable failure");
 	static_assert((eastl::is_assignable<Assignable, Pod2>::value       == false),  "is_assignable failure");
-	static_assert((eastl::is_assignable<PodA&, PodA>::value            == true),   "is_assignable failure");
 	
 	#if EASTL_TYPE_TRAIT_is_assignable_CONFORMANCE
 		// These might not succeed unless the implementation is conforming.
 		static_assert((eastl::is_assignable<Assignable, Assignable>::value == true),  "is_assignable failure");
 		static_assert((eastl::is_assignable<Assignable, Pod1>::value       == true),  "is_assignable failure");
+		static_assert((eastl::is_assignable<PodA&, PodA>::value            == true),  "is_assignable failure");
 
 		// These cannot succeed unless the implementation is conforming.
 		static_assert((eastl::is_assignable<void, void>::value             == false),  "is_assignable failure");

--- a/test/source/TestTypeTraits.cpp
+++ b/test/source/TestTypeTraits.cpp
@@ -1006,7 +1006,8 @@ int TestTypeTraits()
 	static_assert((eastl::is_assignable<char*, const char*>::value     == false),  "is_assignable failure");
 	static_assert((eastl::is_assignable<PodA, PodB*>::value            == false),  "is_assignable failure");
 	static_assert((eastl::is_assignable<Assignable, Pod2>::value       == false),  "is_assignable failure");
-
+	static_assert((eastl::is_assignable<PodA&, PodA>::value            == true),   "is_assignable failure");
+	
 	#if EASTL_TYPE_TRAIT_is_assignable_CONFORMANCE
 		// These might not succeed unless the implementation is conforming.
 		static_assert((eastl::is_assignable<Assignable, Assignable>::value == true),  "is_assignable failure");

--- a/test/source/TestTypeTraits.cpp
+++ b/test/source/TestTypeTraits.cpp
@@ -1006,7 +1006,7 @@ int TestTypeTraits()
 	static_assert((eastl::is_assignable<char*, const char*>::value     == false),  "is_assignable failure");
 	static_assert((eastl::is_assignable<PodA, PodB*>::value            == false),  "is_assignable failure");
 	static_assert((eastl::is_assignable<Assignable, Pod2>::value       == false),  "is_assignable failure");
-	
+
 	#if EASTL_TYPE_TRAIT_is_assignable_CONFORMANCE
 		// These might not succeed unless the implementation is conforming.
 		static_assert((eastl::is_assignable<Assignable, Assignable>::value == true),  "is_assignable failure");


### PR DESCRIPTION
Fixing an issue in type_traits where is_assignable<T, U> would not be fully defined in MSVC 2013+. For example,  assigning a value of a struct to a ref of a struct of the same type would previously fail.

is_assignable<T,U> et al should now well-defined by utilizing eastl::declval, which should function in MSVC 2013 and later. EASTL_TYPE_TRAIT_is_assignable_CONFORMANCE is now defined, as well.