### PR TITLE
Adding support for typed get for tuple, e.g. get<typename T>(tuple<Ts...>& t)

### DIFF
--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -159,17 +159,20 @@ struct tuple_index<T, TupleTypes<>>
 	static const size_t index = 0;
 };
 
-template <typename T, typename... Ts>
-struct tuple_index<T, TupleTypes<T, Ts...>>
+template <typename T, typename... TsRest>
+struct tuple_index<T, TupleTypes<T, TsRest...>>
 {
 	typedef int DuplicateTypeCheck;
-	static_assert(is_void<typename tuple_index<T, TupleTypes<Ts...>>::DuplicateTypeCheck>::value, "duplicate type T in tuple_vector::get<T>(); unique types must be provided in declaration, or only use get<size_t>()");
+	// after finding type T in the list of types, try to find type T in TsRest.
+	// If we stumble back into this version of tuple_index, i.e. type T appears twice in the list of types, then DuplicateTypeCheck will be of type int, and the statiC_assert will fail.
+	// If we don't, then we'll go through the version of tuple_index above, where all of the types have been exhausted, and DuplicateTypeCheck will be void.
+	static_assert(is_void<typename tuple_index<T, TupleTypes<TsRest...>>::DuplicateTypeCheck>::value, "duplicate type T in tuple_vector::get<T>(); unique types must be provided in declaration, or only use get<size_t>()");
 
 	static const size_t index = 0;
 };
 
-template <typename T, typename Ts, typename... TsRest>
-struct tuple_index<T, TupleTypes<Ts, TsRest...>>
+template <typename T, typename TsHead, typename... TsRest>
+struct tuple_index<T, TupleTypes<TsHead, TsRest...>>
 {
 	typedef typename tuple_index<T, TupleTypes<TsRest...>>::DuplicateTypeCheck DuplicateTypeCheck;
 	static const size_t index = tuple_index<T, TupleTypes<TsRest...>>::index + 1;

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -67,7 +67,7 @@ class tuple_size<Internal::TupleImpl<Indices, Ts...>> : public integral_constant
 {
 };
 
-// tuple_element helper
+// tuple_element helper to be able to isolate a type given an index
 template <size_t I, typename T>
 class tuple_element
 {
@@ -142,6 +142,41 @@ class tuple_element<I, volatile Internal::TupleImpl<Indices, Ts...>> : public tu
 template <size_t I, typename Indices, typename... Ts>
 class tuple_element<I, const volatile Internal::TupleImpl<Indices, Ts...>> : public tuple_element<
 																				 I, const volatile tuple<Ts...>>
+{
+};
+
+// attempt to isolate index given a type
+template <typename T, typename Tuple>
+struct tuple_index
+{
+};
+
+template <typename T>
+struct tuple_index<T, TupleTypes<>>
+{
+	typedef void DuplicateTypeCheck;
+	tuple_index() = delete; // tuple_index should only be used for compile-time assistance, and never be instantiated
+	static const size_t index = 0;
+};
+
+template <typename T, typename... Ts>
+struct tuple_index<T, TupleTypes<T, Ts...>>
+{
+	typedef int DuplicateTypeCheck;
+	static_assert(is_void<typename tuple_index<T, TupleTypes<Ts...>>::DuplicateTypeCheck>::value, "duplicate type T in tuple_vector::get<T>(); unique types must be provided in declaration, or only use get<size_t>()");
+
+	static const size_t index = 0;
+};
+
+template <typename T, typename Ts, typename... TsRest>
+struct tuple_index<T, TupleTypes<Ts, TsRest...>>
+{
+	typedef typename tuple_index<T, TupleTypes<TsRest...>>::DuplicateTypeCheck DuplicateTypeCheck;
+	static const size_t index = tuple_index<T, TupleTypes<TsRest...>>::index + 1;
+};
+
+template <typename T, typename Indices, typename... Ts>
+struct tuple_index<T, Internal::TupleImpl<Indices, Ts...>> : public tuple_index<T, TupleTypes<Ts...>>
 {
 };
 
@@ -349,6 +384,14 @@ const tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices
 template <size_t I, typename Indices, typename... Ts>
 tuple_element_t<I, TupleImpl<Indices, Ts...>>&& get(TupleImpl<Indices, Ts...>&& t);
 
+template <typename T, typename Indices, typename... Ts>
+T& get(TupleImpl<Indices, Ts...>& t);
+
+template <typename T, typename Indices, typename... Ts>
+const T& get(const TupleImpl<Indices, Ts...>& t);
+
+template <typename T, typename Indices, typename... Ts>
+T&& get(TupleImpl<Indices, Ts...>&& t);
 
 template <size_t... Indices, typename... Ts>
 struct TupleImpl<integer_sequence<size_t, Indices...>, Ts...> : public TupleLeaf<Indices, Ts>...
@@ -406,6 +449,27 @@ tuple_element_t<I, TupleImpl<Indices, Ts...>>&& get(TupleImpl<Indices, Ts...>&& 
 {
 	typedef tuple_element_t<I, TupleImpl<Indices, Ts...>> Type;
 	return static_cast<Type&&>(static_cast<Internal::TupleLeaf<I, Type>&>(t).getInternal());
+}
+
+template <typename T, typename Indices, typename... Ts>
+T& get(TupleImpl<Indices, Ts...>& t)
+{
+	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
+	return static_cast<Internal::TupleLeaf<Index::index, T>&>(t).getInternal();
+}
+
+template <typename T, typename Indices, typename... Ts>
+const T& get(const TupleImpl<Indices, Ts...>& t)
+{
+	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
+	return static_cast<const Internal::TupleLeaf<Index::index, T>&>(t).getInternal();
+}
+
+template <typename T, typename Indices, typename... Ts>
+T&& get(TupleImpl<Indices, Ts...>&& t)
+{
+	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
+	return static_cast<Type&&>(static_cast<Internal::TupleLeaf<Index::index, T>&>(t).getInternal());
 }
 
 // TupleLike
@@ -699,6 +763,15 @@ private:
 
 	template <size_t I, typename... Ts_>
 	friend tuple_element_t<I, tuple<Ts_...>>&& get(tuple<Ts_...>&& t);
+
+	template <typename T, typename... ts_>
+	friend T& get(tuple<ts_...>& t);
+
+	template <typename T, typename... ts_>
+	friend const T& get(const tuple<ts_...>& t);
+
+	template <typename T, typename... ts_>
+	friend T&& get(tuple<ts_...>&& t);
 };
 
 template <>
@@ -724,6 +797,24 @@ template <size_t I, typename... Ts>
 inline tuple_element_t<I, tuple<Ts...>>&& get(tuple<Ts...>&& t)
 {
 	return get<I>(move(t.mImpl));
+}
+
+template <typename T, typename... Ts>
+inline T& get(tuple<Ts...>& t)
+{
+	return get<T>(t.mImpl);
+}
+
+template <typename T, typename... Ts>
+inline const T& get(const tuple<Ts...>& t)
+{
+	return get<T>(t.mImpl);
+}
+
+template <typename T, typename... Ts>
+inline T&& get(tuple<Ts...>&& t)
+{
+	return get<T>(move(t.mImpl));
 }
 
 template <typename... Ts>

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -469,7 +469,7 @@ template <typename T, typename Indices, typename... Ts>
 T&& get(TupleImpl<Indices, Ts...>&& t)
 {
 	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
-	return static_cast<Type&&>(static_cast<Internal::TupleLeaf<Index::index, T>&>(t).getInternal());
+	return static_cast<T&&>(static_cast<Internal::TupleLeaf<Index::index, T>&>(t).getInternal());
 }
 
 // TupleLike

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -164,7 +164,7 @@ struct tuple_index<T, TupleTypes<T, TsRest...>>
 {
 	typedef int DuplicateTypeCheck;
 	// after finding type T in the list of types, try to find type T in TsRest.
-	// If we stumble back into this version of tuple_index, i.e. type T appears twice in the list of types, then DuplicateTypeCheck will be of type int, and the statiC_assert will fail.
+	// If we stumble back into this version of tuple_index, i.e. type T appears twice in the list of types, then DuplicateTypeCheck will be of type int, and the static_assert will fail.
 	// If we don't, then we'll go through the version of tuple_index above, where all of the types have been exhausted, and DuplicateTypeCheck will be void.
 	static_assert(is_void<typename tuple_index<T, TupleTypes<TsRest...>>::DuplicateTypeCheck>::value, "duplicate type T in tuple_vector::get<T>(); unique types must be provided in declaration, or only use get<size_t>()");
 

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -209,7 +209,7 @@ int TestTuple()
 	}
 
 	{
-		// Test some other edge cases with typed-getter
+		// Test some other cases with typed-getter
 		tuple<double, double, bool> aTupleWithRepeatedType(1.0f, 2.0f, true);
 		EATEST_VERIFY(get<bool>(aTupleWithRepeatedType) == true);
 
@@ -218,6 +218,19 @@ int TestTuple()
 
 		tuple<bool, double, double> yetAnotherTupleWithRepeatedType(true, 1.0f, 2.0f);
 		EATEST_VERIFY(get<bool>(anotherTupleWithRepeatedType) == true);
+
+		struct floatOne { float val; };
+		struct floatTwo { float val; };
+		tuple<floatOne, floatTwo> aTupleOfStructs({ 1.0f }, { 2.0f } );
+		EATEST_VERIFY(get<floatOne>(aTupleOfStructs).val == 1.0f);
+		EATEST_VERIFY(get<floatTwo>(aTupleOfStructs).val == 2.0f);
+		
+		const tuple<double, double, bool> aConstTuple(aTupleWithRepeatedType);
+		const bool& constRef = get<bool>(aConstTuple);
+		EATEST_VERIFY(constRef == true);
+
+		const bool&& constRval = get<bool>(eastl::move(aTupleWithRepeatedType));
+		EATEST_VERIFY(constRval == true);
 	}
 
 	{

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -130,9 +130,12 @@ int TestTuple()
 		EATEST_VERIFY(get<0>(aSingleElementTuple) == 1);
 		get<0>(aSingleElementTuple) = 2;
 		EATEST_VERIFY(get<0>(aSingleElementTuple) == 2);
+		get<int>(aSingleElementTuple) = 3;
+		EATEST_VERIFY(get<int>(aSingleElementTuple) == 3);
 
 		const tuple<int> aConstSingleElementTuple(3);
 		EATEST_VERIFY(get<0>(aConstSingleElementTuple) == 3);
+		EATEST_VERIFY(get<int>(aConstSingleElementTuple) == 3);
 
 		tuple<DefaultConstructibleType> aDefaultConstructedTuple;
 		EATEST_VERIFY(get<0>(aDefaultConstructedTuple).mVal == DefaultConstructibleType::defaultVal);
@@ -167,6 +170,10 @@ int TestTuple()
 		EATEST_VERIFY(get<0>(aTuple) == 1);
 		EATEST_VERIFY(get<1>(aTuple) == 1.0f);
 		EATEST_VERIFY(get<2>(aTuple) == true);
+		EATEST_VERIFY(get<int>(aTuple) == 1);
+		EATEST_VERIFY(get<float>(aTuple) == 1.0f);
+		EATEST_VERIFY(get<bool>(aTuple) == true);
+
 		get<1>(aTuple) = 2.0f;
 		EATEST_VERIFY(get<1>(aTuple) == 2.0f);
 
@@ -199,6 +206,18 @@ int TestTuple()
 		tuple<int, float, bool> aDefaultInitializedTuple;
 		EATEST_VERIFY(get<0>(aDefaultInitializedTuple) == 0 && get<1>(aDefaultInitializedTuple) == 0.0f &&
 					  get<2>(aDefaultInitializedTuple) == false);
+	}
+
+	{
+		// Test some other edge cases with typed-getter
+		tuple<double, double, bool> aTupleWithRepeatedType(1.0f, 2.0f, true);
+		EATEST_VERIFY(get<bool>(aTupleWithRepeatedType) == true);
+
+		tuple<double, bool, double> anotherTupleWithRepeatedType(1.0f, true, 2.0f);
+		EATEST_VERIFY(get<bool>(anotherTupleWithRepeatedType) == true);
+
+		tuple<bool, double, double> yetAnotherTupleWithRepeatedType(true, 1.0f, 2.0f);
+		EATEST_VERIFY(get<bool>(anotherTupleWithRepeatedType) == true);
 	}
 
 	{


### PR DESCRIPTION
These commits add the typed "get" that was added for tuple in c++14, e.g. items (5)-(7) as described here: http://en.cppreference.com/w/cpp/utility/tuple/get

A couple tests of this are left in in-line with some other simple base tests for the tuple, as well as a small battery of tests specifically for checking some edge cases and each overload of the function.

The "tuple_index" helper was implemented similarly to "tuple_element". It calculates the index by iterating down to the type in question being 'found' in the template list, counting up the index value as it goes. The duplicatetypecheck is used to verify that we have not hit a type before; this allows for protection against a typed access to an ambiguous TupleLeaf. For example, with "tuple<double, double, bool> aTupleWithRepeatedType;", if "get<double>(aTupleWithRepeatedType)" is entered in, the follwing compilation errors will come up:

> 1>C:\Users\Cypher\Coding Projects\EASTL\include\EASTL/tuple.h(166): error C2338: duplicate type T in tuple_vector::get<T>(); unique types must be provided in declaration, or only use get<size_t>()
> 1>  C:\Users\Cypher\Coding Projects\EASTL\include\EASTL/tuple.h(180): note: see reference to class template instantiation 'eastl::tuple_index<T,eastl::TupleTypes<double,double,bool>>' being compiled
> 1>          with
> 1>          [
> 1>              T=double
> 1>          ]
> 1>  C:\Users\Cypher\Coding Projects\EASTL\include\EASTL/tuple.h(458): note: see reference to class template instantiation 'eastl::tuple_index<T,eastl::Internal::TupleImpl<eastl::integer_sequence<std::size_t,0,1,2>,double,double,bool>>' being compiled
> 1>          with
> 1>          [
> 1>              T=double
> 1>          ]
> 1>  C:\Users\Cypher\Coding Projects\EASTL\include\EASTL/tuple.h(805): note: see reference to function template instantiation 'T &eastl::Internal::get<T,eastl::integer_sequence<std::size_t,0,1,2>,double,double,bool>(eastl::Internal::TupleImpleastl::integer_sequence<std::size_t,0,1,2,double,double,bool> &)' being compiled
> 1>          with
> 1>          [
> 1>              T=double
> 1>          ]
> 1>  C:\Users\Cypher\Coding Projects\EASTL\test\source\TestTuple.cpp(215): note: see reference to function template instantiation 'T &eastl::get<double,double,double,bool>(eastl::tuple<double,double,bool> &)' being compiled
> 1>          with
> 1>          [
> 1>              T=double
> 1>          ]

Sadly, I don't know if there's a way to add a unit test of a guaranteed failure, to make sure that that _never_ compiles, so that has been omitted.
