### PR TITLE
Use move instead of copy in vector::insert()/set_capacity()

### DIFF
--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -890,8 +890,7 @@ namespace eastl
 			else if(n < (size_type)(mpEnd - mpBegin))
 				resize(n);
 
-			this_type temp(*this);  // This is the simplest way to accomplish this, 
-			swap(temp);             // and it is as efficient as any other.
+			shrink_to_fit();
 		}
 		else // Else new capacity > size.
 		{
@@ -1628,8 +1627,8 @@ namespace eastl
 
 				if(n < nExtra) // If the inserted values are entirely within initialized memory (i.e. are before mpEnd)...
 				{
-					eastl::uninitialized_copy_ptr(mpEnd - n, mpEnd, mpEnd);
-					eastl::copy_backward(destPosition, mpEnd - n, mpEnd); // We need copy_backward because of potential overlap issues.
+					eastl::uninitialized_move_ptr(mpEnd - n, mpEnd, mpEnd);
+					eastl::move_backward(destPosition, mpEnd - n, mpEnd); // We need move_backward because of potential overlap issues.
 					eastl::copy(first, last, destPosition);
 				}
 				else
@@ -1637,7 +1636,7 @@ namespace eastl
 					BidirectionalIterator iTemp = first;
 					eastl::advance(iTemp, nExtra);
 					eastl::uninitialized_copy_ptr(iTemp, last, mpEnd);
-					eastl::uninitialized_copy_ptr(destPosition, mpEnd, mpEnd + n - nExtra);
+					eastl::uninitialized_move_ptr(destPosition, mpEnd, mpEnd + n - nExtra);
 					eastl::copy_backward(first, iTemp, destPosition + nExtra);
 				}
 
@@ -1702,14 +1701,14 @@ namespace eastl
 
 				if(n < nExtra)
 				{
-					eastl::uninitialized_copy_ptr(mpEnd - n, mpEnd, mpEnd);
-					eastl::copy_backward(destPosition, mpEnd - n, mpEnd); // We need copy_backward because of potential overlap issues.
+					eastl::uninitialized_move_ptr(mpEnd - n, mpEnd, mpEnd);
+					eastl::move_backward(destPosition, mpEnd - n, mpEnd); // We need move_backward because of potential overlap issues.
 					eastl::fill(destPosition, destPosition + n, temp);
 				}
 				else
 				{
 					eastl::uninitialized_fill_n_ptr(mpEnd, n - nExtra, temp);
-					eastl::uninitialized_copy_ptr(destPosition, mpEnd, mpEnd + n - nExtra);
+					eastl::uninitialized_move_ptr(destPosition, mpEnd, mpEnd + n - nExtra);
 					eastl::fill(destPosition, mpEnd, temp);
 				}
 


### PR DESCRIPTION
In vector::insert() and vector::set_capacity(), a copy is made on existing elements. Use move semantic in order to avoid copy when elements are moved or vector resize.

Here an example of code which show the extra copy done:
```
struct CheckCopy
{
	CheckCopy() : m_Value(0) {}
	CheckCopy(int value) : m_Value(value) {}
	CheckCopy(const CheckCopy& iOther) : m_Value(iOther.m_Value) { std::cout << "Copy" << std::endl; }
	CheckCopy(CheckCopy&& iOther) : m_Value(iOther.m_Value) {}
	void operator =(const CheckCopy& iOther) { m_Value = iOther.m_Value; std::cout << "Copy" << std::endl; }
	void operator =(CheckCopy&& iOther) { m_Value= iOther.m_Value; }

	int m_Value;
};

void TestInsert()
{
	eastl::vector<CheckCopy> myVector1;
	myVector1.reserve(20);
	for (int idx = 0; idx < 2; ++idx)
		myVector1.push_back().m_Value = idx;

	eastl::vector<CheckCopy> myVector2;
	for (int idx = 0; idx < 3; ++idx)
		myVector2.push_back().m_Value = 10 + idx;

	// Here we have 5 copy instead of 3
	std::cout << "Insert 3 elts with iterator" << std::endl;
	myVector1.insert(myVector1.begin(), myVector2.begin(), myVector2.end());

	eastl::vector<CheckCopy> myVector3;
	myVector3.push_back().m_Value = 20;
	// Here we have 6 copy instead of one
	std::cout << "Insert 1 elt with iterator" << std::endl;
	myVector1.insert(myVector1.begin(), myVector3.begin(), myVector3.end());

	// Here we have 8 copy instead of 2
	std::cout << "Insert 1 elt" << std::endl;
	myVector1.insert(myVector1.begin(), 1, CheckCopy(17));

	// Here we have 18 copy instead of 11
	std::cout << "Insert 10 elts" << std::endl;
	myVector1.insert(myVector1.begin(), 10, CheckCopy(17));

	// No copy should be done here.
	std::cout << "set_capacity(2)" << std::endl;
	myVector1.set_capacity(2);
}
```

Here the associated issue: #67 