### PR TITLE
Compatibility with VC9 and VC10

### DIFF
--- a/include/EASTL/iterator.h
+++ b/include/EASTL/iterator.h
@@ -1013,6 +1013,8 @@ namespace eastl
 		return it;
 	}
 
+
+#if defined(EA_COMPILER_CPP11_ENABLED) && EA_COMPILER_CPP11_ENABLED
 	
 	// eastl::data
 	//
@@ -1063,6 +1065,8 @@ namespace eastl
 	template <class E> 
 	EA_CONSTEXPR bool empty(std::initializer_list<E> il) EA_NOEXCEPT
 		{ return il.size() == 0; }
+
+#endif // defined(EA_COMPILER_CPP11_ENABLED) && EA_COMPILER_CPP11_ENABLED
 
 
 	// eastl::begin / eastl::end

--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -290,6 +290,8 @@ namespace eastl
 		eastl::swap_ranges(a, a + N, b);
 	}
 
+#if EASTL_MOVE_SEMANTICS_ENABLED
+
 	/// exchange
 	///
 	/// Replaces the value of the first argument with the new value provided.  
@@ -314,6 +316,8 @@ namespace eastl
 			return old_value;
 		}
 	#endif
+
+#endif // EASTL_MOVE_SEMANTICS_ENABLED
 
 	/// as_const
 	///

--- a/test/packages/EABase/include/Common/EABase/config/eacompiler.h
+++ b/test/packages/EABase/include/Common/EABase/config/eacompiler.h
@@ -248,7 +248,7 @@
 			#define EA_COMPILER_CPP11_ENABLED 1
 		#elif defined(__GNUC__) && defined(__GXX_EXPERIMENTAL_CXX0X__)
 			#define EA_COMPILER_CPP11_ENABLED 1
-		#elif defined(_MSC_VER)         // Microsoft unilaterally enables its C++11 support; there is no way to disable it.
+		#elif defined(_MSC_VER) && _MSC_VER >= 1600         // Microsoft unilaterally enables its C++11 support; there is no way to disable it.
 			#define EA_COMPILER_CPP11_ENABLED 1
 		#elif defined(__SN_VER__) && (__SN_VER__ >= 43001)
 			#if __option(cpp11)


### PR DESCRIPTION
These fixes make EASTL usable with VC9 and VC10 (without C++11 support).