### PR TITLE
Remove the need to update pacman before mingw appveyor builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ cmake_install.cmake
 **/*.vcxproj.filters
 *.VC.opendb
 *.sdf
+**/*.suo
+**/*.user
 .vs/*
 **/Debug/*
 CMakeFiles/*
@@ -33,6 +35,6 @@ Release/*
 Win32/*
 x64/*
 MinSizeRel/*
-build/*
+build*/*
 Testing/*
 %ALLUSERSPROFILE%/*

--- a/scripts/ci-pre.cmd
+++ b/scripts/ci-pre.cmd
@@ -9,8 +9,6 @@ if [%PLATFORM%]==[MinGW_x64] set platform_string=x86_64
 rem Checks if the platform variable contains MinGW
 if not [x%PLATFORM:MinGW=%]==[x%PLATFORM%] (
 	set "PATH=C:\msys64\usr\bin;%PATH%"
-	C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
-	C:\msys64\usr\bin\pacman --noconfirm -Syu
 	C:\msys64\usr\bin\pacman --noconfirm --needed -S mingw-w64-%platform_string%-clang mingw-w64-x86_64-ninja
 )
 

--- a/test/packages/EABase/include/Common/EABase/eahave.h
+++ b/test/packages/EABase/include/Common/EABase/eahave.h
@@ -571,7 +571,10 @@
 	#elif defined(__GNUC__) && defined(__CYGWIN__)
 		#define EA_HAVE_ISNAN(x)  __isnand(x)        /* declared nowhere, it seems. */
 		#define EA_HAVE_ISINF(x)  __isinfd(x)
-	#else /* Most GCC, EDG, Dinkumware, and MinGW(-w64). */
+	#elif defined(EA_PLATFORM_MINGW)                 /* Meant to workaround a GCC limitation where cmath undefines isnan, both GCC and clang have std::isnan */
+		#define EA_HAVE_ISNAN(x)  std::isnan(x)      /* declared in <cmath> */
+		#define EA_HAVE_ISINF(x)  std::isinf(x)
+	#else /* Most GCC, EDG, Dinkumware. */
 		#define EA_HAVE_ISNAN(x)  isnan(x)           /* declared in <math.h> */
 		#define EA_HAVE_ISINF(x)  isinf(x)
 	#endif


### PR DESCRIPTION
This should speed up the process of the build somewhat.
Quite a significant portion of the time was needing to update gcc and clang to version that wouldn't crash during the build.
Appveyor now runs gcc 5.3 and clang 3.8, clang still needs to be installed, but that's not really slow.

Depends on my previous PR #75.