### PR TITLE
Fix C99 inttypes.h macro redefinition warnings with VS2013 and above

### DIFF
--- a/test/packages/EABase/include/Common/EABase/eabase.h
+++ b/test/packages/EABase/include/Common/EABase/eabase.h
@@ -114,8 +114,8 @@
 	   #define __STDC_FORMAT_MACROS
 	#endif
 	// The GCC PSP compiler defines standard int types (e.g. uint32_t) but not PRId8, etc.
-	// MSVC doesn't include an inttypes.h header.
-	#if !defined(EA_COMPILER_MSVC)
+	// MSVC added support for inttypes.h header in VS2013.
+	#if !defined(EA_COMPILER_MSVC) || EA_COMPILER_VERSION >= 1800
 		#include <inttypes.h> // PRId8, SCNd8, etc.
 	#endif
 	#if defined(_MSC_VER)
@@ -355,7 +355,7 @@
 	typedef double              double_t;
 #endif
 
-#if defined(EA_COMPILER_HAS_INTTYPES) && !defined(EA_COMPILER_MSVC)
+#if defined(EA_COMPILER_HAS_INTTYPES) && (!defined(EA_COMPILER_MSVC) || EA_COMPILER_VERSION >= 1800)
 	#define EA_COMPILER_HAS_C99_FORMAT_MACROS 
 #endif
 

--- a/test/packages/EABase/include/Common/EABase/eabase.h
+++ b/test/packages/EABase/include/Common/EABase/eabase.h
@@ -115,7 +115,7 @@
 	#endif
 	// The GCC PSP compiler defines standard int types (e.g. uint32_t) but not PRId8, etc.
 	// MSVC added support for inttypes.h header in VS2013.
-	#if !defined(EA_COMPILER_MSVC) || EA_COMPILER_VERSION >= 1800
+	#if !defined(EA_COMPILER_MSVC) || (defined(EA_COMPILER_MSVC) && EA_COMPILER_VERSION >= 1800)
 		#include <inttypes.h> // PRId8, SCNd8, etc.
 	#endif
 	#if defined(_MSC_VER)
@@ -355,7 +355,7 @@
 	typedef double              double_t;
 #endif
 
-#if defined(EA_COMPILER_HAS_INTTYPES) && (!defined(EA_COMPILER_MSVC) || EA_COMPILER_VERSION >= 1800)
+#if defined(EA_COMPILER_HAS_INTTYPES) && (!defined(EA_COMPILER_MSVC) || (defined(EA_COMPILER_MSVC) && EA_COMPILER_VERSION >= 1800))
 	#define EA_COMPILER_HAS_C99_FORMAT_MACROS 
 #endif
 


### PR DESCRIPTION
This commit fixes [issue 47](https://github.com/electronicarts/EASTL/issues/47).

According to [Visual C++ Team Blog](https://blogs.msdn.microsoft.com/vcblog/2013/07/19/c99-library-support-in-visual-studio-2013/), MSVC added C99 library support in Visual Studio 2013.