### PR TITLE
#103 Change some of the members in red_black_tree from public to protected

### DIFF
--- a/include/EASTL/internal/red_black_tree.h
+++ b/include/EASTL/internal/red_black_tree.h
@@ -216,7 +216,7 @@ namespace eastl
 	{
 		typedef ExtractKey extract_key;
 
-	public:
+	protected:
 		Compare mCompare; // To do: Make sure that empty Compare classes go away via empty base optimizations.
 
 	public:
@@ -235,7 +235,7 @@ namespace eastl
 	{
 		typedef ExtractKey extract_key;
 
-	public:
+	protected:
 		Compare mCompare; // To do: Make sure that empty Compare classes go away via empty base optimizations.
 
 	public:
@@ -252,7 +252,7 @@ namespace eastl
 	{
 		typedef eastl::use_first<Pair> extract_key;
 
-	public:
+	protected:
 		Compare mCompare; // To do: Make sure that empty Compare classes go away via empty base optimizations.
 
 	public:
@@ -269,7 +269,7 @@ namespace eastl
 	{
 		typedef eastl::use_first<Pair> extract_key;
 
-	public:
+	protected:
 		Compare mCompare; // To do: Make sure that empty Compare classes go away via empty base optimizations.
 
 	public:
@@ -364,7 +364,7 @@ namespace eastl
 
 		using base_type::mCompare;
 
-	public:
+	protected:
 		rbtree_node_base  mAnchor;      /// This node acts as end() and its mpLeft points to begin(), and mpRight points to rbegin() (the last node on the right).
 		size_type         mnSize;       /// Stores the count of nodes in the tree (not counting the anchor node).
 		allocator_type    mAllocator;   // To do: Use base class optimization to make this go away.

--- a/include/EASTL/internal/red_black_tree.h
+++ b/include/EASTL/internal/red_black_tree.h
@@ -167,12 +167,12 @@ namespace eastl
 		typedef Reference                                   reference;
 		typedef EASTL_ITC_NS::bidirectional_iterator_tag    iterator_category;
 
-	public:
+	protected:
 		node_type* mpNode;
+		explicit rbtree_iterator(const node_type* pNode);
 
 	public:
 		rbtree_iterator();
-		explicit rbtree_iterator(const node_type* pNode);
 		rbtree_iterator(const iterator& x);
 
 		reference operator*() const;
@@ -183,6 +183,31 @@ namespace eastl
 
 		rbtree_iterator& operator--();
 		rbtree_iterator  operator--(int);
+
+	public:
+		template <typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
+		friend bool operator==(const rbtree_iterator<T, PointerA, ReferenceA>& a, 
+							   const rbtree_iterator<T, PointerB, ReferenceB>& b)
+		{
+			return a.mpNode == b.mpNode;
+		}
+
+
+		template <typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
+		friend bool operator!=(const rbtree_iterator<T, PointerA, ReferenceA>& a, 
+							   const rbtree_iterator<T, PointerB, ReferenceB>& b)
+		{
+			return a.mpNode != b.mpNode;
+		}
+
+		friend bool operator!=(const rbtree_iterator<T, Pointer, Reference>& a, 
+							   const rbtree_iterator<T, Pointer, Reference>& b)
+		{
+			return a.mpNode != b.mpNode;
+		}
+	protected:
+		template <typename, typename, typename, typename, typename, bool, bool> friend class rbtree;
+		friend const_iterator;
 
 	}; // rbtree_iterator
 
@@ -675,6 +700,7 @@ namespace eastl
 	// The C++ defect report #179 requires that we support comparisons between const and non-const iterators.
 	// Thus we provide additional template paremeters here to support this. The defect report does not
 	// require us to support comparisons between reverse_iterators and const_reverse_iterators.
+	/*
 	template <typename T, typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
 	inline bool operator==(const rbtree_iterator<T, PointerA, ReferenceA>& a, 
 						   const rbtree_iterator<T, PointerB, ReferenceB>& b)
@@ -699,6 +725,7 @@ namespace eastl
 	{
 		return a.mpNode != b.mpNode;
 	}
+	*/
 
 
 

--- a/include/EASTL/internal/red_black_tree.h
+++ b/include/EASTL/internal/red_black_tree.h
@@ -184,28 +184,19 @@ namespace eastl
 		rbtree_iterator& operator--();
 		rbtree_iterator  operator--(int);
 
-	public:
-		template <typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
-		friend bool operator==(const rbtree_iterator<T, PointerA, ReferenceA>& a, 
-							   const rbtree_iterator<T, PointerB, ReferenceB>& b)
-		{
-			return a.mpNode == b.mpNode;
-		}
-
-
-		template <typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
-		friend bool operator!=(const rbtree_iterator<T, PointerA, ReferenceA>& a, 
-							   const rbtree_iterator<T, PointerB, ReferenceB>& b)
-		{
-			return a.mpNode != b.mpNode;
-		}
-
-		friend bool operator!=(const rbtree_iterator<T, Pointer, Reference>& a, 
-							   const rbtree_iterator<T, Pointer, Reference>& b)
-		{
-			return a.mpNode != b.mpNode;
-		}
 	protected:
+		template <typename Tp, typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
+		friend bool operator==(const rbtree_iterator<Tp, PointerA, ReferenceA>& a, 
+							   const rbtree_iterator<Tp, PointerB, ReferenceB>& b);
+
+		template <typename Tp, typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
+		friend bool operator!=(const rbtree_iterator<Tp, PointerA, ReferenceA>& a, 
+							   const rbtree_iterator<Tp, PointerB, ReferenceB>& b);
+
+		template <typename Tp, typename PointerA, typename ReferenceA>
+		friend bool operator!=(const rbtree_iterator<Tp, PointerA, ReferenceA>& a, 
+							   const rbtree_iterator<Tp, PointerA, ReferenceA>& b);
+
 		template <typename, typename, typename, typename, typename, bool, bool> friend class rbtree;
 		friend const_iterator;
 
@@ -700,7 +691,6 @@ namespace eastl
 	// The C++ defect report #179 requires that we support comparisons between const and non-const iterators.
 	// Thus we provide additional template paremeters here to support this. The defect report does not
 	// require us to support comparisons between reverse_iterators and const_reverse_iterators.
-	/*
 	template <typename T, typename PointerA, typename ReferenceA, typename PointerB, typename ReferenceB>
 	inline bool operator==(const rbtree_iterator<T, PointerA, ReferenceA>& a, 
 						   const rbtree_iterator<T, PointerB, ReferenceB>& b)
@@ -725,7 +715,6 @@ namespace eastl
 	{
 		return a.mpNode != b.mpNode;
 	}
-	*/
 
 
 

--- a/include/EASTL/map.h
+++ b/include/EASTL/map.h
@@ -380,7 +380,7 @@ namespace eastl
 		// result is a range of size zero or one.
 		const iterator itLower(lower_bound(key));
 
-		if((itLower == end()) || mCompare(key, itLower.mpNode->mValue.first)) // If at the end or if (key is < itLower)...
+		if((itLower == end()) || mCompare(key, itLower->first)) // If at the end or if (key is < itLower)...
 			return eastl::pair<iterator, iterator>(itLower, itLower);
 
 		iterator itUpper(itLower);
@@ -396,7 +396,7 @@ namespace eastl
 		// See equal_range above for comments.
 		const const_iterator itLower(lower_bound(key));
 
-		if((itLower == end()) || mCompare(key, itLower.mpNode->mValue.first)) // If at the end or if (key is < itLower)...
+		if((itLower == end()) || mCompare(key, itLower->first)) // If at the end or if (key is < itLower)...
 			return eastl::pair<const_iterator, const_iterator>(itLower, itLower);
 
 		const_iterator itUpper(itLower);
@@ -612,7 +612,7 @@ namespace eastl
 		const iterator itLower(lower_bound(key));
 		iterator       itUpper(itLower);
 
-		while((itUpper != end()) && !mCompare(key, itUpper.mpNode->mValue.first))
+		while((itUpper != end()) && !mCompare(key, itUpper->first))
 			++itUpper;
 
 		return eastl::pair<iterator, iterator>(itLower, itUpper);
@@ -629,7 +629,7 @@ namespace eastl
 		const const_iterator itLower(lower_bound(key));
 		const_iterator       itUpper(itLower);
 
-		while((itUpper != end()) && !mCompare(key, itUpper.mpNode->mValue.first))
+		while((itUpper != end()) && !mCompare(key, itUpper->first))
 			++itUpper;
 
 		return eastl::pair<const_iterator, const_iterator>(itLower, itUpper);

--- a/include/EASTL/set.h
+++ b/include/EASTL/set.h
@@ -566,7 +566,7 @@ namespace eastl
 		const iterator itLower(lower_bound(k));
 		iterator       itUpper(itLower);
 
-		while((itUpper != end()) && !mCompare(k, itUpper.mpNode->mValue))
+		while((itUpper != end()) && !mCompare(k, *itUpper))
 			++itUpper;
 
 		return eastl::pair<iterator, iterator>(itLower, itUpper);


### PR DESCRIPTION
This commit is a solution to issue #103 
These changes include:
1. Change some members in red_black_tree from public to protected
2. Add friend declaration in class rbtree_iterator so that rbtree can access its private member
3. Some of the lines in map and set were using the iterator incorrectly. Instead of accessing mpNode and mValue, use the -> and * operators in the iterator directly.