### PR TITLE
Add support for Android on ARM64

### DIFF
--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -634,6 +634,8 @@ namespace eastl
             #include <signal.h>
             #include <unistd.h>
             #define EASTL_DEBUG_BREAK() kill( getpid(), SIGINT )
+        #elif defined(EA_PROCESSOR_ARM64) && defined(__GNUC__)
+            #define EASTL_DEBUG_BREAK() asm("brk 10")
         #elif defined(EA_PROCESSOR_ARM) && defined(__GNUC__)
             #define EASTL_DEBUG_BREAK() asm("BKPT 10")     // The 10 is arbitrary. It's just a unique id.
         #elif defined(EA_PROCESSOR_ARM) && defined(__ARMCC_VERSION)

--- a/test/packages/EABase/include/Common/EABase/config/eaplatform.h
+++ b/test/packages/EABase/include/Common/EABase/config/eaplatform.h
@@ -151,6 +151,9 @@
 		#define EA_ABI_ARM_LINUX 1  // a.k.a. "ARM eabi"
 		#define EA_PROCESSOR_ARM32 1
 		#define EA_PLATFORM_DESCRIPTION "Android on ARM"
+	#elif defined(__aarch64__)
+		#define EA_PROCESSOR_ARM64 1
+		#define EA_PLATFORM_DESCRIPTION "Android on ARM64"
 	#elif defined(__i386__)
 		#define EA_PROCESSOR_X86 1
 		#define EA_PLATFORM_DESCRIPTION "Android on x86"

--- a/test/packages/EATest/include/EATest/EATest.h
+++ b/test/packages/EATest/include/EATest/EATest.h
@@ -122,6 +122,8 @@
                 #define EATEST_DEBUG_BREAK() {__asm__("int $3\n" : : ); }
             #elif defined(EA_PROCESSOR_ARM) && defined(__APPLE__)
                 #define EATEST_DEBUG_BREAK() asm("trap") // Apparently __builtin_trap() doesn't let you continue execution, so we don't use it.
+            #elif defined(EA_PROCESSOR_ARM64) && defined(__GNUC__)
+                #define EATEST_DEBUG_BREAK() asm("brk 10")
             #elif defined(EA_PROCESSOR_ARM) && defined(__GNUC__)
                 #define EATEST_DEBUG_BREAK() asm("BKPT 10")     // The 10 is arbitrary. It's just a unique id.
             #elif defined(EA_PROCESSOR_ARM) && defined(__ARMCC_VERSION)


### PR DESCRIPTION
The library previously did not recognize Android on ARM64 targets, and did not support breakpoints even if the target were to be recognized. Fixed by adding the required definitions in EABase/config/eaplatform.h, and adding a correct breakpoint instruction to both EASTL and EATest.