### PR TITLE
Remove Mojibake

### DIFF
--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -403,8 +403,8 @@ namespace eastl
 		// GCC has a bug with overloading rvalue and lvalue function templates.
 		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54425
 		// 
-		// error: ‘eastl::pair<T1, T2>::pair(T1&&) [with T1 = const int&; T2 = const int&]’ cannot be overloaded
-		// error: with ‘eastl::pair<T1, T2>::pair(const T1&) [with T1 = const int&; T2 = const int&]’
+		// error: 'eastl::pair<T1, T2>::pair(T1&&) [with T1 = const int&; T2 = const int&]' cannot be overloaded
+		// error: with 'eastl::pair<T1, T2>::pair(const T1&) [with T1 = const int&; T2 = const int&]'
 		#if EASTL_MOVE_SEMANTICS_ENABLED && !defined(EA_COMPILER_GNUC)
 			EA_CPP14_CONSTEXPR pair(T1&& x)
 				: first(eastl::move(x)),


### PR DESCRIPTION
Because non-ascii characters exist, Visual Studio 2017 Japanese version compiler occurs warning message as below.
> warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。