### PR TITLE
define _SSIZE_T_DEFINED, when defining typedef ssize_t

### DIFF
--- a/test/packages/EABase/include/Common/EABase/eabase.h
+++ b/test/packages/EABase/include/Common/EABase/eabase.h
@@ -587,12 +587,15 @@
 	// As of this writing, all non-GCC compilers significant to us implement 
 	// uintptr_t the same as size_t. However, this isn't guaranteed to be 
 	// so for all compilers, as size_t may be based on int, long, or long long.
-	#if defined(_MSC_VER) && (EA_PLATFORM_PTR_SIZE == 8)
-        #define _SSIZE_T_DEFINED
-		typedef __int64 ssize_t;
-	#else
-        #define _SSIZE_T_DEFINED
-		typedef long ssize_t;
+	#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
+		#define _SSIZE_T_
+		#define _SSIZE_T_DEFINED
+
+		#if defined(_MSC_VER) && (EA_PLATFORM_PTR_SIZE == 8)
+			typedef __int64 ssize_t;
+		#else
+			typedef long ssize_t;
+		#endif
 	#endif
 #else
 	#include <sys/types.h>

--- a/test/packages/EABase/include/Common/EABase/eabase.h
+++ b/test/packages/EABase/include/Common/EABase/eabase.h
@@ -588,8 +588,10 @@
 	// uintptr_t the same as size_t. However, this isn't guaranteed to be 
 	// so for all compilers, as size_t may be based on int, long, or long long.
 	#if defined(_MSC_VER) && (EA_PLATFORM_PTR_SIZE == 8)
+        #define _SSIZE_T_DEFINED
 		typedef __int64 ssize_t;
 	#else
+        #define _SSIZE_T_DEFINED
 		typedef long ssize_t;
 	#endif
 #else


### PR DESCRIPTION
Not defining that ssize_t has already been typedef'ed might upset other libraries trying to define it, too. The `_SSIZE_T_DEFINED` macro is taken from ZeroMQ, since their checking for it. Considering ZeroMQ is a pretty widespread & successfully deployed library, I'd consider using that name safe.
Without it, ZeroMQ fails to compile, due to conflicting types used for ssize_t.