### PR TITLE
Check for empty range in vector::erase(first,last)

### DIFF
--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -1283,9 +1283,12 @@ namespace eastl
 				EASTL_FAIL_MSG("vector::erase -- invalid position");
 		#endif
  
-		iterator const position = const_cast<value_type*>(eastl::move(const_cast<value_type*>(last), const_cast<value_type*>(mpEnd), const_cast<value_type*>(first)));
-		eastl::destruct(position, mpEnd);
-		mpEnd -= (last - first);
+		if (first != last)
+		{
+			iterator const position = const_cast<value_type*>(eastl::move(const_cast<value_type*>(last), const_cast<value_type*>(mpEnd), const_cast<value_type*>(first)));
+			eastl::destruct(position, mpEnd);
+			mpEnd -= (last - first);
+		}
  
 		return const_cast<value_type*>(first);
 	}

--- a/test/source/TestVector.cpp
+++ b/test/source/TestVector.cpp
@@ -144,6 +144,15 @@ public:
 	testmovable& operator=(testmovable&&) EA_NOEXCEPT { return *this; }
 };
 
+#if EASTL_MOVE_SEMANTICS_ENABLED
+struct testmovetoself
+{
+	testmovetoself() : movedtoself(false) { }
+	testmovetoself(const testmovetoself & other) { movedtoself = other.movedtoself; }
+	testmovetoself & operator= (testmovetoself && other) { movedtoself = true; return *this; }
+	bool movedtoself;
+};
+#endif
 
 #if EASTL_VARIABLE_TEMPLATES_ENABLED
 	/// custom type-trait which checks if a type is comparable via the <operator.
@@ -1427,6 +1436,15 @@ int TestVector()
 		eastl::vector<testmovable> moveablevec;
 		testmovable moveable;
 		moveablevec.insert(moveablevec.end(), eastl::move(moveable));
+	}
+
+	{
+		// Calling erase of empty range should not call a move assignment to self
+		eastl::vector<testmovetoself> moveablevec;
+		moveablevec.push_back(testmovetoself());
+		EATEST_VERIFY(!moveablevec[0].movedtoself);
+		moveablevec.erase(moveablevec.begin(), moveablevec.begin());
+		EATEST_VERIFY(!moveablevec[0].movedtoself);
 	}
 #endif
 

--- a/test/source/TestVector.cpp
+++ b/test/source/TestVector.cpp
@@ -145,12 +145,12 @@ public:
 };
 
 #if EASTL_MOVE_SEMANTICS_ENABLED
-struct testmovetoself
+struct TestMoveAssignToSelf
 {
-	testmovetoself() : movedtoself(false) { }
-	testmovetoself(const testmovetoself & other) { movedtoself = other.movedtoself; }
-	testmovetoself & operator= (testmovetoself && other) { movedtoself = true; return *this; }
-	bool movedtoself;
+	TestMoveAssignToSelf() : mMovedToSelf(false) { }
+	TestMoveAssignToSelf(const TestMoveAssignToSelf & other) { mMovedToSelf = other.mMovedToSelf; }
+	TestMoveAssignToSelf & operator= (TestMoveAssignToSelf && other) { mMovedToSelf = true; return *this; }
+	bool mMovedToSelf;
 };
 #endif
 
@@ -1440,11 +1440,11 @@ int TestVector()
 
 	{
 		// Calling erase of empty range should not call a move assignment to self
-		eastl::vector<testmovetoself> moveablevec;
-		moveablevec.push_back(testmovetoself());
-		EATEST_VERIFY(!moveablevec[0].movedtoself);
-		moveablevec.erase(moveablevec.begin(), moveablevec.begin());
-		EATEST_VERIFY(!moveablevec[0].movedtoself);
+		eastl::vector<TestMoveAssignToSelf> v1;
+		v1.push_back(TestMoveAssignToSelf());
+		EATEST_VERIFY(!v1[0].mMovedToSelf);
+		v1.erase(v1.begin(), v1.begin());
+		EATEST_VERIFY(!v1[0].mMovedToSelf);
 	}
 #endif
 


### PR DESCRIPTION
When erase() is called on a vector with an empty range (first == last),
it should be a no-op. If erase() does not check for this case, it can
end up calling the move assignment operator for an obect with itself as
the source and dest. This is unnecessary work at best, and at worst
could cause problems if the object's implementation of the move
assignment does not handle this case well, leaving the object in an
undefined state.

This fix simply adds a check for first==last and avoids doing any work
in that case.