### PR TITLE
Allow move-constructing optional_storage with value_type

### DIFF
--- a/include/EASTL/optional.h
+++ b/include/EASTL/optional.h
@@ -81,6 +81,7 @@ namespace eastl
 			inline optional_storage() EA_NOEXCEPT : empty_val('\0') {}
 			inline optional_storage(const optional_storage& other) : val(other.val), engaged(other.engaged) { }
 			inline optional_storage(const value_type& v) : val(v), engaged(true) {}
+			inline optional_storage(value_type &&v) : val(eastl::move(v)), engaged(true) {}
 			inline ~optional_storage()
 			{
 				if (engaged)
@@ -129,6 +130,7 @@ namespace eastl
 			inline optional_storage() EA_NOEXCEPT : empty_val('\0') {}
 			inline optional_storage(const optional_storage& other) : val(other.val), engaged(other.engaged) { }
 			inline optional_storage(const value_type& v) : val(v), engaged(true) {}
+			inline optional_storage(value_type &&v) : val(eastl::move(v)), engaged(true) {}
 
 			// Removed to make optional<T> trivially destructible when T is trivially destructible.
 			//

--- a/test/source/TestOptional.cpp
+++ b/test/source/TestOptional.cpp
@@ -32,6 +32,16 @@ struct destructor_test
 };
 bool destructor_test::destructor_ran = false;
 
+/////////////////////////////////////////////////////////////////////////////
+struct move_test
+{
+    move_test() {}
+    move_test(move_test const &other) { was_moved = false; }
+    move_test(move_test &&other) { was_moved = true; }
+    static bool was_moved;
+};
+bool move_test::was_moved = false;
+
 
 /////////////////////////////////////////////////////////////////////////////
 // TestOptional
@@ -176,6 +186,12 @@ int TestOptional()
 			}
 		}
 	}
+
+    {
+        move_test t;
+        optional<move_test> o(eastl::move(t));
+        VERIFY(move_test::was_moved);
+    }
 
 	#if EASTL_VARIADIC_TEMPLATES_ENABLED 
 	{


### PR DESCRIPTION
`optional_storage`, wasn't move constructing `value_type` when passing in an rvalue. The following patch fixes this, `optional` is now properly constructed by moving the optional value in the container, instead of copying it.

Here is a small test case, showing the bug:

```
#include <stdio.h>
#include <EASTL/optional.h>
using namespace eastl;

struct Test {
    Test() { printf("Test()\n"); }
    Test(Test const &other) noexcept { this->x = other.x; printf("Test(Test const &)\n"); }
    Test(Test &&other) noexcept { this->x = other.x; other.x = 0; printf("Test(Test &&)\n"); }
    ~Test() { printf("~Test() (x = %d)\n", x); }
    int x;
};

optional<Test> get_test()
{
    Test t;
    t.x = 5;
    return move(t);
}

int main()
{
    auto test = get_test();
    if (test)
        printf("x = %d\n", test->x);
    else
        printf("x = ?\n");
}
```

If this snippet is executed before this patch, the output will be:

```
Test()
Test(Test const &)
~Test() (x = 5)
x = 5
~Test() (x = 5)
```

which shows that `optional` is copying test into it's storage, instead of moving it. After the patch is applied, we'll see that `Test` is now moved into `optional`: 

```
Test()
Test(Test &&)
~Test() (x = 0)
x = 5
~Test() (x = 5)
```


The following is the same code, but with clangs stdlib version on godbolt: https://godbolt.org/g/ZcAYrf

It shows that the stdlib optional is also moving `Test` into `optional` instead of copying it.