### PR TITLE
EASTL 3.05.09 was released, but the version not bumped

### DIFF
--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -105,8 +105,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef EASTL_VERSION
-	#define EASTL_VERSION   "3.05.08"
-	#define EASTL_VERSION_N  30508
+	#define EASTL_VERSION   "3.05.09"
+	#define EASTL_VERSION_N  30509
 #endif
 
 


### PR DESCRIPTION
Was that done intentionally? Otherwise, feel free to merge the PR.