### PR TITLE
fix eastl::optional<> MSVC /Wall level 4 warnings

### DIFF
--- a/include/EASTL/optional.h
+++ b/include/EASTL/optional.h
@@ -35,11 +35,11 @@
 
 #if defined(EASTL_OPTIONAL_ENABLED) && EASTL_OPTIONAL_ENABLED
 
-EA_DISABLE_VC_WARNING(4583) // destructor is not implicitly called
+EA_DISABLE_VC_WARNING(4582 4583) // constructor/destructor is not implicitly called
 
 namespace eastl
 {
-	#ifdef EASTL_EXCEPTIONS_ENABLED
+	#if EASTL_EXCEPTIONS_ENABLED
 		#define EASTL_OPTIONAL_NOEXCEPT 
 	#else
 		#define EASTL_OPTIONAL_NOEXCEPT EA_NOEXCEPT


### PR DESCRIPTION
optional.h(42): warning C4574: 'EASTL_EXCEPTIONS_ENABLED' is defined to be '0': did you mean to use '#if EASTL_EXCEPTIONS_ENABLED'?
optional.h(81): warning C4582: 'eastl::Internal::optional_storage<T,false>::val': constructor is not implicitly called