### PR TITLE
fix broken include numeric.h dependency on iterator.h

### DIFF
--- a/include/EASTL/numeric.h
+++ b/include/EASTL/numeric.h
@@ -13,6 +13,7 @@
 
 
 #include <EASTL/internal/config.h>
+#include <EASTL/iterator.h>
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
 	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.


### PR DESCRIPTION
If numeric.h included before iterator.h was included it won't compile
on GCC, e.g:

EASTL/numeric.h:132:35: error: expected initializer before ¿<¿ token typedef typename iterator_traits<InputIterator>::value_type value_type;

and Clang, e.g.:

EASTL/numeric.h:159:20: error: expected a qualified name after 'typename'
                typedef typename iterator_traits<InputIterator>::value_type value_type;