### PR TITLE
fix eastl::string_view compare for string with different sizes

### DIFF
--- a/include/EASTL/string_view.h
+++ b/include/EASTL/string_view.h
@@ -158,9 +158,19 @@ namespace eastl
 			return this_type(mpBegin + pos, count);
 		}
 
-		EA_CONSTEXPR int compare(basic_string_view sw) const EA_NOEXCEPT
+		static EA_CPP14_CONSTEXPR int compare(const T* pBegin1, const T* pEnd1, const T* pBegin2, const T* pEnd2)
 		{
-			return Compare(mpBegin, sw.data(), eastl::min_alt(size(), sw.size()));
+			const ptrdiff_t n1   = pEnd1 - pBegin1;
+			const ptrdiff_t n2   = pEnd2 - pBegin2;
+			const ptrdiff_t nMin = eastl::min_alt(n1, n2);
+			const int       cmp  = Compare(pBegin1, pBegin2, (size_t)nMin);
+
+			return (cmp != 0 ? cmp : (n1 < n2 ? -1 : (n1 > n2 ? 1 : 0)));
+		}
+
+		EA_CPP14_CONSTEXPR int compare(basic_string_view sw) const EA_NOEXCEPT
+		{
+			return compare(mpBegin, mpBegin + mnCount, sw.mpBegin, sw.mpBegin + sw.mnCount);
 		}
 
 		EA_CONSTEXPR int compare(size_type pos1, size_type count1, basic_string_view sw) const

--- a/test/source/TestStringView.inl
+++ b/test/source/TestStringView.inl
@@ -247,6 +247,11 @@ int TEST_STRING_NAME()
 			}
 
 			{
+				VERIFY(StringViewT(LITERAL("Aa")).compare(StringViewT(LITERAL("A"))) > 0);
+				VERIFY(StringViewT(LITERAL("A")).compare(StringViewT(LITERAL("Aa"))) < 0);
+			}
+
+			{
 				StringViewT sw1(LITERAL("Hello, World"));
 				StringViewT sw2(LITERAL("Hello, WWorld"));
 				StringViewT sw3(LITERAL("Hello, Wzorld"));
@@ -283,7 +288,7 @@ int TEST_STRING_NAME()
 		{
 			StringViewT sw(LITERAL("*** Hello"));
 			VERIFY(sw.compare(4, 5, LITERAL("Hello")) == 0);
-			VERIFY(sw.compare(4, 5, LITERAL("Hello 555")) == 0);
+			VERIFY(sw.compare(4, 5, LITERAL("Hello 555")) != 0);
 			VERIFY(sw.compare(4, 5, LITERAL("hello")) != 0);
 		}
 
@@ -292,7 +297,7 @@ int TEST_STRING_NAME()
 			StringViewT sw(LITERAL("*** Hello ***"));
 			VERIFY(sw.compare(4, 5, LITERAL("Hello"), 5) == 0);
 			VERIFY(sw.compare(0, 1, LITERAL("*"), 1) == 0);
-			VERIFY(sw.compare(0, 2, LITERAL("**"), 1) == 0);
+			VERIFY(sw.compare(0, 2, LITERAL("**"), 1) != 0);
 			VERIFY(sw.compare(0, 2, LITERAL("**"), 2) == 0);
 			VERIFY(sw.compare(0, 2, LITERAL("^^"), 2) != 0);
 		}


### PR DESCRIPTION
string_view.compare method should return non-zero result,
when compare strings with different sizes and same common part.

Added helper static compare function similar to used in string.h.
Fixed string_view compare method using static compare function.
Fixed and added unit tests for string_view.