### PR TITLE
fix noexcept warnings in case when compilie with EA_COMPILER_NO_NOEXCEPT

### DIFF
--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -390,7 +390,7 @@ namespace eastl
 				}
 			}
 
-			inline void SetEndPtr(value_type* pEnd) noexcept
+			inline void SetEndPtr(value_type* pEnd) EA_NOEXCEPT
 			{
 				if(IsSSO())
 					sso.mnSize = char(pEnd - SSOBufferPtr());
@@ -398,7 +398,7 @@ namespace eastl
 					heap.mpEnd = pEnd;
 			}
 
-			inline void SetBeginPtr(value_type* pBegin) noexcept
+			inline void SetBeginPtr(value_type* pBegin) EA_NOEXCEPT
 			{
 				// NOTE(rparolin): sso.mpBegin and heap.mpBegin occupy the same memory location so only one write is necessary.
 				//
@@ -406,7 +406,7 @@ namespace eastl
 				heap.mpBegin = pBegin;
 			}
 
-			inline void SetCapacityPtr(value_type* pCapacity) noexcept
+			inline void SetCapacityPtr(value_type* pCapacity) EA_NOEXCEPT
 			{
 				if(!IsSSO())
 					heap.mpCapacity = pCapacity;
@@ -416,7 +416,7 @@ namespace eastl
 			 // }
 			}
 
-			inline void ClearSSOBuffer() noexcept
+			inline void ClearSSOBuffer() EA_NOEXCEPT
 			{
 				if(IsSSO())
 				{
@@ -434,8 +434,8 @@ namespace eastl
 
 	public:
 		// Constructor, destructor
-		basic_string() noexcept(noexcept(allocator_type()));
-		explicit basic_string(const allocator_type& allocator) noexcept;
+		basic_string() EA_NOEXCEPT_IF(EA_NOEXCEPT_EXPR(allocator_type()));
+		explicit basic_string(const allocator_type& allocator) EA_NOEXCEPT;
 		basic_string(const this_type& x, size_type position, size_type n = npos);
 		basic_string(const value_type* p, size_type n, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
 		EASTL_STRING_EXPLICIT basic_string(const value_type* p, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
@@ -447,7 +447,7 @@ namespace eastl
 		basic_string(CtorSprintf, const value_type* pFormat, ...);
 		basic_string(std::initializer_list<value_type> init, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
 
-		basic_string(this_type&& x) noexcept;
+		basic_string(this_type&& x) EA_NOEXCEPT;
 		basic_string(this_type&& x, const allocator_type& allocator);
 
 		template <typename OtherCharType>
@@ -726,7 +726,7 @@ namespace eastl
 	///////////////////////////////////////////////////////////////////////////////
 
 	template <typename T, typename Allocator>
-	inline basic_string<T, Allocator>::basic_string() noexcept(noexcept(allocator_type()))
+	inline basic_string<T, Allocator>::basic_string() EA_NOEXCEPT_IF(EA_NOEXCEPT_EXPR(allocator_type()))
 	    : mPair(allocator_type(EASTL_BASIC_STRING_DEFAULT_NAME))
 	{
 		AllocateSelf();
@@ -734,7 +734,7 @@ namespace eastl
 
 
 	template <typename T, typename Allocator>
-	inline basic_string<T, Allocator>::basic_string(const allocator_type& allocator) noexcept
+	inline basic_string<T, Allocator>::basic_string(const allocator_type& allocator) EA_NOEXCEPT
 	    : mPair(allocator)
 	{
 		AllocateSelf();
@@ -872,7 +872,7 @@ namespace eastl
 
 
 	template <typename T, typename Allocator>
-	basic_string<T, Allocator>::basic_string(this_type&& x) noexcept
+	basic_string<T, Allocator>::basic_string(this_type&& x) EA_NOEXCEPT
 		: mPair(x.get_allocator())
 	{
 		internalLayout() = eastl::move(x.internalLayout());

--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -204,13 +204,13 @@ namespace eastl
 		using base_type::internalAllocator;
 
 	public:
-		vector() noexcept(noexcept(allocator_type()));
-		explicit vector(const allocator_type& allocator) noexcept;
+		vector() EA_NOEXCEPT_IF(EA_NOEXCEPT_EXPR(allocator_type()));
+		explicit vector(const allocator_type& allocator) EA_NOEXCEPT;
 		explicit vector(size_type n, const allocator_type& allocator = EASTL_VECTOR_DEFAULT_ALLOCATOR);
 		vector(size_type n, const value_type& value, const allocator_type& allocator = EASTL_VECTOR_DEFAULT_ALLOCATOR);
 		vector(const this_type& x);
 		vector(const this_type& x, const allocator_type& allocator);
-		vector(this_type&& x) noexcept;
+		vector(this_type&& x) EA_NOEXCEPT;
 		vector(this_type&& x, const allocator_type& allocator);
 		vector(std::initializer_list<value_type> ilist, const allocator_type& allocator = EASTL_VECTOR_DEFAULT_ALLOCATOR);
 
@@ -493,7 +493,7 @@ namespace eastl
 	///////////////////////////////////////////////////////////////////////
 
 	template <typename T, typename Allocator>
-	inline vector<T, Allocator>::vector() noexcept(noexcept(allocator_type()))
+	inline vector<T, Allocator>::vector() EA_NOEXCEPT_IF(EA_NOEXCEPT_EXPR(allocator_type()))
 		: base_type()
 	{
 		// Empty
@@ -501,7 +501,7 @@ namespace eastl
 
 
 	template <typename T, typename Allocator>
-	inline vector<T, Allocator>::vector(const allocator_type& allocator) noexcept
+	inline vector<T, Allocator>::vector(const allocator_type& allocator) EA_NOEXCEPT
 		: base_type(allocator)
 	{
 		// Empty
@@ -543,7 +543,7 @@ namespace eastl
 
 
 	template <typename T, typename Allocator>
-	inline vector<T, Allocator>::vector(this_type&& x) noexcept
+	inline vector<T, Allocator>::vector(this_type&& x) EA_NOEXCEPT
 		: base_type(eastl::move(x.internalAllocator()))  // vector requires move-construction of allocator in this case.
 	{
 		DoSwap(x);
@@ -1954,7 +1954,7 @@ namespace eastl
 
 
 	template <typename T, typename Allocator>
-	inline void swap(vector<T, Allocator>& a, vector<T, Allocator>& b) noexcept(noexcept(a.swap(b)))
+	inline void swap(vector<T, Allocator>& a, vector<T, Allocator>& b) EA_NOEXCEPT_IF(EA_NOEXCEPT_EXPR(a.swap(b)))
 	{
 		a.swap(b);
 	}


### PR DESCRIPTION
E.g.:

EASTL/string.h(419): error C2220: warning treated as error - no 'object' file generated
EASTL/string.h(419): warning C4577: 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify /EHsc