### PR TITLE
Fix unused variable warning/error in tuple.

### DIFF
--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -746,7 +746,7 @@ template <>
 class tuple<>
 {
 public:
-	void swap(tuple& t) {}
+	void swap(tuple&) {}
 };
 
 template <size_t I, typename... Ts>


### PR DESCRIPTION
Minor Issue. An unused variable in `template<> tuple::swap()` causes issues with Wall & Werror enabled.