### PR TITLE
Fixing eastl::bitset natvis

### DIFF
--- a/doc/EASTL.natvis
+++ b/doc/EASTL.natvis
@@ -421,12 +421,7 @@
       <Size>kSize</Size>
 
       <Loop>
-        <If Condition="iBitInWord == 0">
-          <Exec>bBitValue = (mWord[iWord] % 2 != 0) ? true : false</Exec>
-        </If>
-        <Else>
-          <Exec>bBitValue = (mWord[iWord] >> iBitInWord) != 0 ? true : false</Exec>
-        </Else>
+        <Exec>bBitValue = ((mWord[iWord] >> iBitInWord) % 2) != 0 ? true : false</Exec>
         <Item>bBitValue</Item>
         <Exec>iBitInWord++</Exec>
         <If Condition="iBitInWord == kBitsPerWord">


### PR DESCRIPTION
Fixes #154, the bitset natvis wasn't showing correct values.

![image](https://user-images.githubusercontent.com/2878094/39640988-f4cd41e6-4fcc-11e8-93c7-16afc45defdb.png)
