### PR TITLE
Correct the name of container's reset member function

### DIFF
--- a/doc/EASTL Best Practices.html
+++ b/doc/EASTL Best Practices.html
@@ -129,7 +129,7 @@
 </tr>
 <tr>
 <td>27</td>
-<td><a href="#Best.27">Consider using reset() for fast container teardown.</a></td>
+<td><a href="#Best.27">Consider using reset_lose_memory() for fast container teardown.</a></td>
 </tr>
 <tr>
 <td>28</td>
@@ -953,13 +953,13 @@ Pass and return containers by reference instead of value.</p>
 }</p>
 <p class="faq-answer">The problem with the above is that widgetList is passed by value and not by reference. Thus the a copy of the container is made and passed instead of a reference of the container being passed. This may seem obvious to some but this happens periodically and the compiler gives no warning and the code will often execute properly, but inefficiently. Of course there are some occasions where you really do want to pass values instead of references.</p>
 <p class="faq-question"><a name="Best.27"></a>27
-Consider using reset() for fast container teardown.</p>
+Consider using reset_lose_memory() for fast container teardown.</p>
 <p class="faq-answer">EASTL containers have a reset function which unilaterally resets the container to a newly constructed state. The contents of the container are forgotten; no destructors are called and no memory is freed. This is a risky but power function for the purpose of implementing very fast temporary containers. There are numerous cases in high performance programming when you want to create a temporary container out of a scratch buffer area, use the container, and then just &quot;vaporize&quot; it, as it would be waste of time to go through the trouble of clearing the container and destroying and freeing the objects. Such functionality is often used with hash tables or maps and with a stack allocator (a.k.a. linear allocator).</p>
 <p class="faq-answer">Here's an example of usage of the reset function and a PPMalloc-like StackAllocator:</p>
 <p class="code-example">pStackAllocator-&gt;push_bookmark();<br>
   hash_set&lt;Widget, less&lt;Widget&gt;, StackAllocator&gt; wSet(pStackAllocator);<br>
 &lt;use wSet&gt;<br>
-  wSet.reset();<br>
+  wSet.reset_lose_memory();<br>
   pStackAllocator-&gt;pop_bookmark();</p>
 <p></p>
 <p class="faq-question">  <a name="Best.28"></a>28

--- a/doc/EASTL FAQ.html
+++ b/doc/EASTL FAQ.html
@@ -535,7 +535,7 @@ How does EASTL differ from standard C++ STL?</p>
   <li>allocators work in a simpler way.</li>
   <li>exception handling can be disabled.</li>
   <li>all containers expose/declare their node size, so you can make a node allocator for them.</li>
-  <li>all containers have reset(), which unilaterally forgets their contents.</li>
+  <li>all containers have reset_lose_memory(), which unilaterally forgets their contents.</li>
   <li>all containers have validate() and validate_iterator() functions.</li>
   <li>all containers understand and respect object alignment requirements.</li>
   <li>all containers guarantee no memory allocation upon being newly created as empty.</li>


### PR DESCRIPTION
I might be wrong, but it turns out the source code uses `reset_lose_memory()` instead of `reset()` in question?