### PR TITLE
Made some changes to the sort benchmark so it is less fragile to other modifications.

### DIFF
--- a/benchmark/source/BenchmarkSort.cpp
+++ b/benchmark/source/BenchmarkSort.cpp
@@ -3,21 +3,21 @@
 /////////////////////////////////////////////////////////////////////////////
 
 
+#include <EASTL/bonus/sort_extra.h>
+#include <EASTL/sort.h>
+#include <EASTL/vector.h>
+#include <EAStdC/EAStopwatch.h>
 #include "EASTLBenchmark.h"
 #include "EASTLTest.h"
-#include <EAStdC/EAStopwatch.h>
-#include <EASTL/sort.h>
-#include <EASTL/bonus/sort_extra.h>
-#include <EASTL/vector.h>
 
 #ifdef _MSC_VER
 	#pragma warning(push, 0)
 	#pragma warning(disable: 4350)
 #endif
+#include <stdlib.h>
 #include <algorithm>
 #include <functional>
 #include <vector>
-#include <stdlib.h>
 #ifdef _MSC_VER
 	#pragma warning(pop)
 #endif
@@ -38,43 +38,40 @@ namespace
 	{
 		bool operator()(const ValuePair& vp1, const ValuePair& vp2) const
 		{
-			//return *(const uint64_t*)&vp1 < *(const uint64_t*)&vp2;
+			// return *(const uint64_t*)&vp1 < *(const uint64_t*)&vp2;
 			return (vp1.key == vp2.key) ? (vp1.v < vp2.v) : (vp1.key < vp2.key);
 		}
 	};
 
 	bool operator<(const ValuePair& vp1, const ValuePair& vp2)
 	{
-		//return *(const uint64_t*)&vp1 < *(const uint64_t*)&vp2;
+		// return *(const uint64_t*)&vp1 < *(const uint64_t*)&vp2;
 		return (vp1.key == vp2.key) ? (vp1.v < vp2.v) : (vp1.key < vp2.key);
 	}
 
 	bool operator==(const ValuePair& vp1, const ValuePair& vp2)
 	{
-		//return *(const uint64_t*)&vp1 == *(const uint64_t*)&vp2;
+		// return *(const uint64_t*)&vp1 == *(const uint64_t*)&vp2;
 		return (vp1.key == vp2.key) && (vp1.v == vp2.v);
 	}
-
 }
 
 // VPCompareC
 // Useful for testing the the C qsort function.
 int VPCompareC(const void* elem1, const void* elem2)
-	{ return (int)(*(const uint64_t*)elem1 - *(const uint64_t*)elem2); }
+{
+	return (int)(*(const uint64_t*)elem1 - *(const uint64_t*)elem2);
+}
 
 
+typedef std::vector<ValuePair> StdVectorVP;
+typedef eastl::vector<ValuePair> EaVectorVP;
 
+typedef std::vector<uint32_t> StdVectorInt;
+typedef eastl::vector<uint32_t> EaVectorInt;
 
-
-typedef std::vector<ValuePair>    StdVectorVP;
-typedef eastl::vector<ValuePair>  EaVectorVP;
-
-typedef std::vector<uint32_t>     StdVectorInt;
-typedef eastl::vector<uint32_t>   EaVectorInt;
-
-typedef std::vector<TestObject>   StdVectorTO;
+typedef std::vector<TestObject> StdVectorTO;
 typedef eastl::vector<TestObject> EaVectorTO;
-
 
 
 namespace
@@ -116,8 +113,6 @@ namespace
 	}
 
 
-
-
 	void TestQuickSortStdInt(EA::StdC::Stopwatch& stopwatch, StdVectorInt& stdVectorInt)
 	{
 		stopwatch.Restart();
@@ -134,8 +129,6 @@ namespace
 		stopwatch.Stop();
 		sprintf(Benchmark::gScratchBuffer, "%u", (unsigned)eaVectorInt[0]);
 	}
-
-
 
 
 	void TestQuickSortStdTO(EA::StdC::Stopwatch& stopwatch, StdVectorTO& stdVectorTO)
@@ -158,30 +151,30 @@ namespace
 } // namespace
 
 
-namespace 
+namespace
 {
 	enum SortFunctionType
 	{
-		sf_qsort,                   // C qsort
-		sf_shell_sort,              // eastl::shell_sort.
-		sf_heap_sort,               // eastl::heap_sort
-		sf_merge_sort,              // eastl::merge_sort
-		sf_merge_sort_buffer,       // eastl::merge_sort_buffer
-		sf_comb_sort,               // eastl::comb_sort
-		sf_bubble_sort,             // eastl::bubble_sort
-		sf_selection_sort,          // eastl::selection_sort
-		sf_shaker_sort,             // eastl::shaker_sort
-		sf_quick_sort,              // eastl::quick_sort
-		sf_tim_sort,                // eastl::tim_sort
-		sf_insertion_sort,          // eastl::insertion_sort
-		sf_std_sort,                // std::sort
-		sf_radix_sort,              // eastl::radix_sort (unconventional sort)
-		sf_count                    // 
+		sf_qsort,             // C qsort
+		sf_shell_sort,        // eastl::shell_sort.
+		sf_heap_sort,         // eastl::heap_sort
+		sf_merge_sort,        // eastl::merge_sort
+		sf_merge_sort_buffer, // eastl::merge_sort_buffer
+		sf_comb_sort,         // eastl::comb_sort
+		sf_bubble_sort,       // eastl::bubble_sort
+		sf_selection_sort,    // eastl::selection_sort
+		sf_shaker_sort,       // eastl::shaker_sort
+		sf_quick_sort,        // eastl::quick_sort
+		sf_tim_sort,          // eastl::tim_sort
+		sf_insertion_sort,    // eastl::insertion_sort
+		sf_std_sort,          // std::sort
+		sf_radix_sort,        // eastl::radix_sort (unconventional sort)
+		sf_count              //
 	};
 
 	const char* GetSortFunctionName(int sortFunctionType)
 	{
-		switch(sortFunctionType)
+		switch (sortFunctionType)
 		{
 			case sf_quick_sort:
 				return "eastl::sort";
@@ -233,15 +226,15 @@ namespace
 
 	enum RandomizationType
 	{
-		kRandom,                    // Completely random data.
-		kOrdered,                   // Already sorted.
-		kMostlyOrdered,             // Partly sorted already.
+		kRandom,        // Completely random data.
+		kOrdered,       // Already sorted.
+		kMostlyOrdered, // Partly sorted already.
 		kRandomizationTypeCount
 	};
 
 	const char* GetRandomizationTypeName(int randomizationType)
 	{
-		switch(randomizationType)
+		switch (randomizationType)
 		{
 			case kRandom:
 				return "random";
@@ -262,7 +255,7 @@ namespace
 	{
 		typedef RandomType value_type;
 
-		switch(type)
+		switch (type)
 		{
 			default:
 			case kRandomizationTypeCount: // We specify this only to avoid a compiler warning about not testing for it.
@@ -274,21 +267,26 @@ namespace
 
 			case kOrdered:
 			{
-				for(eastl_size_t i = 0; i < v.size(); ++i)
-					v[i] = value_type((value_type)i);   // Note that value_type may be a struct and not an integer. Thus the casting and construction here.
+				for (eastl_size_t i = 0; i < v.size(); ++i)
+					v[i] = value_type((value_type)i); // Note that value_type may be a struct and not an integer. Thus
+					                                  // the casting and construction here.
 				break;
 			}
 
 			case kMostlyOrdered:
 			{
-				for(eastl_size_t i = 0; i < v.size(); ++i)
-					v[i] = value_type((value_type)i);   // Note that value_type may be a struct and not an integer. Thus the casting and construction here.
+				for (eastl_size_t i = 0; i < v.size(); ++i)
+					v[i] = value_type((value_type)i); // Note that value_type may be a struct and not an integer. Thus
+					                                  // the casting and construction here.
 
 				// We order random segments.
 				// The algorithm below in practice will make slightly more than kPercentOrdered be ordered.
-				const eastl_size_t kPercentOrdered = 80; // In actuality, due to statistics, the actual ordered percent will be about 82-85%.
+				const eastl_size_t kPercentOrdered =
+				    80; // In actuality, due to statistics, the actual ordered percent will be about 82-85%.
 
-				for(eastl_size_t n = 0, s = v.size(), nEnd = ((s < (100 - kPercentOrdered)) ? 1 : (s / (100 - kPercentOrdered))); n < nEnd; n++)
+				for (eastl_size_t n = 0, s = v.size(),
+				                  nEnd = ((s < (100 - kPercentOrdered)) ? 1 : (s / (100 - kPercentOrdered)));
+				     n < nEnd; n++)
 				{
 					eastl_size_t i = rng.mRand.RandLimit((uint32_t)s);
 					eastl_size_t j = rng.mRand.RandLimit((uint32_t)s);
@@ -302,8 +300,8 @@ namespace
 	}
 
 
-	char gSlowAssignBuffer1[256] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 /* ... */};
-	char gSlowAssignBuffer2[256] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 /* ... */};
+	char gSlowAssignBuffer1[256] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0 /* ... */};
+	char gSlowAssignBuffer2[256] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0 /* ... */};
 
 
 	// SlowAssign
@@ -316,26 +314,43 @@ namespace
 		static int nAssignCount;
 
 		SlowAssign()
-			{ x = 0; memcpy(gSlowAssignBuffer1, gSlowAssignBuffer2, sizeof(gSlowAssignBuffer1)); }
+		{
+			x = 0;
+			memcpy(gSlowAssignBuffer1, gSlowAssignBuffer2, sizeof(gSlowAssignBuffer1));
+		}
 
 		SlowAssign(const SlowAssign& sa)
-			{ ++nAssignCount; x = sa.x; memcpy(gSlowAssignBuffer1, gSlowAssignBuffer2, sizeof(gSlowAssignBuffer1)); }
+		{
+			++nAssignCount;
+			x = sa.x;
+			memcpy(gSlowAssignBuffer1, gSlowAssignBuffer2, sizeof(gSlowAssignBuffer1));
+		}
 
 		SlowAssign& operator=(const SlowAssign& sa)
-			{ ++nAssignCount; x = sa.x; memcpy(gSlowAssignBuffer1, gSlowAssignBuffer2, sizeof(gSlowAssignBuffer1)); return *this; }
+		{
+			++nAssignCount;
+			x = sa.x;
+			memcpy(gSlowAssignBuffer1, gSlowAssignBuffer2, sizeof(gSlowAssignBuffer1));
+			return *this;
+		}
 
 		SlowAssign& operator=(int a)
-			{ x = (T)a; return *this; }
+		{
+			x = (T)a;
+			return *this;
+		}
 
-		static void Reset()
-			{ nAssignCount = 0; }
+		static void Reset() { nAssignCount = 0; }
 	};
 
-	template<> int SlowAssign<int32_t>::nAssignCount = 0;
+	template <>
+	int SlowAssign<int32_t>::nAssignCount = 0;
 
 	template <typename T>
-	bool operator <(const SlowAssign<T>& a, const SlowAssign<T>& b)
-		{ return a.x < b.x; }
+	bool operator<(const SlowAssign<T>& a, const SlowAssign<T>& b)
+	{
+		return a.x < b.x;
+	}
 
 
 	// SlowCompare
@@ -349,17 +364,16 @@ namespace
 		{
 			++nCompareCount;
 
-			return (a < b) &&   // It happens that gSlowAssignBuffer1 is always zeroed.
-				   (gSlowAssignBuffer1[0] == 0) && (gSlowAssignBuffer1[1] == 0) &&
-				   (gSlowAssignBuffer1[1] == 0) && (gSlowAssignBuffer1[2] == 0) &&
-				   (gSlowAssignBuffer1[4] == 0) && (gSlowAssignBuffer1[5] == 0);
+			return (a < b) && // It happens that gSlowAssignBuffer1 is always zeroed.
+			       (gSlowAssignBuffer1[0] == 0) && (gSlowAssignBuffer1[1] == 0) && (gSlowAssignBuffer1[1] == 0) &&
+			       (gSlowAssignBuffer1[2] == 0) && (gSlowAssignBuffer1[4] == 0) && (gSlowAssignBuffer1[5] == 0);
 		}
 
-		static void Reset()
-			{ nCompareCount = 0; }
+		static void Reset() { nCompareCount = 0; }
 	};
 
-	template<> int SlowCompare<int32_t>::nCompareCount = 0;
+	template <>
+	int SlowCompare<int32_t>::nCompareCount = 0;
 
 
 	// qsort callback functions
@@ -368,20 +382,20 @@ namespace
 	int CompareInteger(const void* a, const void* b)
 	{
 		// Even though you see the following in Internet example code, it doesn't work!
-		// The reason is that it works only if a and b are both >= 0, otherwise large 
+		// The reason is that it works only if a and b are both >= 0, otherwise large
 		// values can cause integer register wraparound. A similar kind of problem happens
 		// if you try to do the same thing with floating point value compares.
 		// See http://www.akalin.cx/2006/06/23/on-the-qsort-comparison-function/
 		// Internet exmaple code:
 		//     return *(const int32_t*)a - *(const int32_t*)b;
 
-		// This double comparison might seem like it's crippling qsort against the 
+		// This double comparison might seem like it's crippling qsort against the
 		// STL-based sorts which do a single compare. But consider that the returning
 		// of -1, 0, +1 gives qsort more information, and its logic takes advantage
-		// of that. 
-		if(*(const T*)a < *(const T*)b)
+		// of that.
+		if (*(const T*)a < *(const T*)b)
 			return -1;
-		if(*(const T*)a > *(const T*)b)
+		if (*(const T*)a > *(const T*)b)
 			return +1;
 		return 0;
 	}
@@ -392,13 +406,12 @@ namespace
 		++SlowCompare<int32_t>::nCompareCount;
 
 		// This code is similar in performance to the C++ SlowCompare template functor above.
-		if((gSlowAssignBuffer1[0] == 0) && (gSlowAssignBuffer1[1] == 0) &&
-		   (gSlowAssignBuffer1[1] == 0) && (gSlowAssignBuffer1[2] == 0) &&
-		   (gSlowAssignBuffer1[4] == 0) && (gSlowAssignBuffer1[5] == 0))
+		if ((gSlowAssignBuffer1[0] == 0) && (gSlowAssignBuffer1[1] == 0) && (gSlowAssignBuffer1[1] == 0) &&
+		    (gSlowAssignBuffer1[2] == 0) && (gSlowAssignBuffer1[4] == 0) && (gSlowAssignBuffer1[5] == 0))
 		{
-			if(*(const int32_t*)a < *(const int32_t*)b)
+			if (*(const int32_t*)a < *(const int32_t*)b)
 				return -1;
-			if(*(const int32_t*)a > *(const int32_t*)b)
+			if (*(const int32_t*)a > *(const int32_t*)b)
 				return +1;
 		}
 
@@ -416,10 +429,9 @@ namespace
 } // namespace
 
 
-
 // Sizes of arrays to be sorted.
-const eastl_size_t kSizesCount = 4;
-const eastl_size_t kSizes[kSizesCount] = { 10, 100, 1000, 10000 };
+const eastl_size_t kSizes[] = {10, 100, 1000, 10000};
+const eastl_size_t kSizesCount = EAArrayCount(kSizes);
 
 
 struct BenchmarkResult
@@ -428,13 +440,10 @@ struct BenchmarkResult
 	uint64_t mCompareCount;
 	uint64_t mAssignCount;
 
-	BenchmarkResult() : mTime(0), mCompareCount(0), mAssignCount(0){ }
+	BenchmarkResult() : mTime(0), mCompareCount(0), mAssignCount(0) {}
 };
 
 BenchmarkResult gResults[kRandomizationTypeCount][kSizesCount][sf_count];
-
-
-
 
 int CompareSortPerformance()
 {
@@ -444,42 +453,50 @@ int CompareSortPerformance()
 	EA::UnitTest::ReportVerbosity(2, "Random seed = %u\n", (unsigned)EA::UnitTest::GetRandSeed());
 
 	EA::UnitTest::RandGenT<int32_t> rng(EA::UnitTest::GetRandSeed());
-	EA::StdC::Stopwatch             stopwatch(EA::StdC::Stopwatch::kUnitsCPUCycles);
-	EA::StdC::Stopwatch             stopwatchGlobal(EA::StdC::Stopwatch::kUnitsSeconds);
-	const eastl_size_t              kArraySizeMax = 50000;
-	const int                       kRunCount = 4;
+	EA::StdC::Stopwatch stopwatch(EA::StdC::Stopwatch::kUnitsCPUCycles);
+	EA::StdC::Stopwatch stopwatchGlobal(EA::StdC::Stopwatch::kUnitsSeconds);
+	const eastl_size_t kArraySizeMax = *eastl::max_element(eastl::begin(kSizes), eastl::end(kSizes));
+	const int kRunCount = 4;
 
-	#if !defined(EA_DEBUG)
-		EA::UnitTest::SetHighThreadPriority();
-	#endif
+#if !defined(EA_DEBUG)
+	EA::UnitTest::SetHighThreadPriority();
+#endif
 
+	eastl::vector<SortFunctionType> allSortFunctions;
+	for (int i = 0; i < sf_count; i++)
+	{
+		allSortFunctions.push_back(SortFunctionType(i));
+	}
 
 	{
+		auto& sortFunctions = allSortFunctions;
+
 		// Regular speed test.
 		// In this case we test the sorting of integral values.
 		// This is probably the most common type of comparison.
 		EA::UnitTest::ReportVerbosity(2, "Sort comparison: Regular speed test\n");
 
-		typedef uint32_t                      ElementType;
-		typedef eastl::less<ElementType>      CompareFunction;
+		typedef uint32_t ElementType;
+		typedef eastl::less<ElementType> CompareFunction;
 		typedef RadixSortElement<ElementType> RadixSortElementType;
 
-		eastl::string sOutput; sOutput.set_capacity(100000);
-		ElementType*  pBuffer = new ElementType[kArraySizeMax];
+		eastl::string sOutput;
+		sOutput.set_capacity(100000);
+		ElementType* pBuffer = new ElementType[kArraySizeMax];
 
 		memset(gResults, 0, sizeof(gResults));
 
 		stopwatchGlobal.Restart();
 
-		for(int c = 0; c < kRunCount; c++)
+		for (int c = 0; c < kRunCount; c++)
 		{
-			for(int i = 0; i < kRandomizationTypeCount; i++)
+			for (int i = 0; i < kRandomizationTypeCount; i++)
 			{
-				for(size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
+				for (size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
 				{
 					const eastl_size_t size = kSizes[sizeType];
 
-					for(int sortFunction = 0; sortFunction < sf_count; sortFunction++)
+					for (SortFunctionType sortFunction : sortFunctions)
 					{
 						eastl::vector<ElementType> v(size);
 
@@ -520,7 +537,8 @@ int CompareSortPerformance()
 
 							case sf_merge_sort:
 								stopwatch.Restart();
-								eastl::merge_sort(v.begin(), v.end(), *get_default_allocator((EASTLAllocatorType*)NULL), CompareFunction());
+								eastl::merge_sort(v.begin(), v.end(), *get_default_allocator((EASTLAllocatorType*)NULL),
+								                  CompareFunction());
 								stopwatch.Stop();
 								break;
 
@@ -558,15 +576,21 @@ int CompareSortPerformance()
 							{
 								eastl::vector<RadixSortElementType> vr(size);
 								eastl::vector<RadixSortElementType> vrBuffer(size);
-								for(eastl_size_t r = 0; r < size; r++) // Normally you wouldn't need to do this copying, but it allows this benchmark code to be cleaner.
+								for (eastl_size_t r = 0; r < size; r++) // Normally you wouldn't need to do this
+								                                        // copying, but it allows this benchmark code to
+								                                        // be cleaner.
 									vr[r].mKey = v[r];
 
 								stopwatch.Restart();
-								eastl::radix_sort<RadixSortElementType*, eastl::Internal::extract_radix_key<RadixSortElementType> >(vr.begin(), vr.end(), &vrBuffer[0]);
+								eastl::radix_sort<RadixSortElementType*,
+								                  eastl::Internal::extract_radix_key<RadixSortElementType> >(
+								    vr.begin(), vr.end(), &vrBuffer[0]);
 								stopwatch.Stop();
 
-								for(eastl_size_t r = 0; r < size; r++)  // Normally you wouldn't need to do this copying, but it allows this benchmark code to be cleaner.
-									 v[r] = vr[r].mKey;
+								for (eastl_size_t r = 0; r < size; r++) // Normally you wouldn't need to do this
+								                                        // copying, but it allows this benchmark code to
+								                                        // be cleaner.
+									v[r] = vr[r].mKey;
 								break;
 							}
 
@@ -586,7 +610,7 @@ int CompareSortPerformance()
 						const uint64_t elapsedTime = (uint64_t)stopwatch.GetElapsedTime();
 
 						// If this result was faster than a previously fastest result, record this one instead.
-						if((c == 0) || (elapsedTime < gResults[i][sizeType][sortFunction].mTime))
+						if ((c == 0) || (elapsedTime < gResults[i][sizeType][sortFunction].mTime))
 							gResults[i][sizeType][sortFunction].mTime = elapsedTime;
 
 						VERIFY(eastl::is_sorted(v.begin(), v.end()));
@@ -604,14 +628,19 @@ int CompareSortPerformance()
 		delete[] pBuffer;
 
 		// Now print the results.
-		for(int i = 0; i < kRandomizationTypeCount; i++)
+		for (int i = 0; i < kRandomizationTypeCount; i++)
 		{
-			for(size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
+			for (size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
 			{
 				const eastl_size_t size = kSizes[sizeType];
 
-				for(int sortFunction = 0; sortFunction < sf_count; sortFunction++)
-					sOutput.append_sprintf("%25s, %14s, Size: %6u, Time: %11I64u ticks\n", GetSortFunctionName(sortFunction), GetRandomizationTypeName(i), (unsigned)size, gResults[i][sizeType][sortFunction].mTime);
+				for (SortFunctionType sortFunction : sortFunctions)
+				{
+					sOutput.append_sprintf("%25s, %14s, Size: %8u, Time: %14I64u ticks %0.2f ticks/elem\n",
+					                       GetSortFunctionName(sortFunction), GetRandomizationTypeName(i),
+					                       (unsigned)size, gResults[i][sizeType][sortFunction].mTime,
+					                       float(gResults[i][sizeType][sortFunction].mTime)/float(size));
+				}
 				sOutput.append("\n");
 			}
 		}
@@ -622,31 +651,35 @@ int CompareSortPerformance()
 	{
 		// Do a speed test for the case of slow compares.
 		// By this we mean to compare sorting speeds when the comparison of elements is slow.
-		// Sort functions use element comparison to tell where elements go and use element 
-		// movement to get them there. But some sorting functions accomplish sorting performance by 
+		// Sort functions use element comparison to tell where elements go and use element
+		// movement to get them there. But some sorting functions accomplish sorting performance by
 		// minimizing the amount of movement, some minimize the amount of comparisons, and the
 		// best do a good job of minimizing both.
+		auto sortFunctions = allSortFunctions;
+		// We can't test this radix_sort because what we need isn't exposed.
+		sortFunctions.erase(eastl::remove(sortFunctions.begin(), sortFunctions.end(), sf_radix_sort), sortFunctions.end());
 		EA::UnitTest::ReportVerbosity(2, "Sort comparison: Slow compare speed test\n");
 
-		typedef int32_t                  ElementType;
+		typedef int32_t ElementType;
 		typedef SlowCompare<ElementType> CompareFunction;
 
-		eastl::string sOutput; sOutput.set_capacity(100000);
-		ElementType*  pBuffer = new ElementType[kArraySizeMax];
+		eastl::string sOutput;
+		sOutput.set_capacity(100000);
+		ElementType* pBuffer = new ElementType[kArraySizeMax];
 
 		memset(gResults, 0, sizeof(gResults));
 
 		stopwatchGlobal.Restart();
 
-		for(int c = 0; c < kRunCount; c++)
+		for (int c = 0; c < kRunCount; c++)
 		{
-			for(int i = 0; i < kRandomizationTypeCount; i++)
+			for (int i = 0; i < kRandomizationTypeCount; i++)
 			{
-				for(size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
+				for (size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
 				{
 					const eastl_size_t size = kSizes[sizeType];
 
-					for(int sortFunction = 0; sortFunction < sf_count; sortFunction++)
+					for (SortFunctionType sortFunction : sortFunctions)
 					{
 						eastl::vector<ElementType> v(size);
 
@@ -688,7 +721,8 @@ int CompareSortPerformance()
 
 							case sf_merge_sort:
 								stopwatch.Restart();
-								eastl::merge_sort(v.begin(), v.end(), *get_default_allocator((EASTLAllocatorType*)NULL), CompareFunction());
+								eastl::merge_sort(v.begin(), v.end(), *get_default_allocator((EASTLAllocatorType*)NULL),
+								                  CompareFunction());
 								stopwatch.Stop();
 								break;
 
@@ -722,10 +756,6 @@ int CompareSortPerformance()
 								stopwatch.Stop();
 								break;
 
-							case sf_radix_sort:
-								// We can't test this because what we need isn't exposed.
-								break;
-
 							case sf_qsort:
 								stopwatch.Restart();
 								qsort(&v[0], (size_t)v.size(), sizeof(ElementType), SlowCompareInt32);
@@ -739,19 +769,15 @@ int CompareSortPerformance()
 								break;
 						}
 
-						if(sortFunction != sf_radix_sort)
-						{
-							const uint64_t elapsedTime = (uint64_t)stopwatch.GetElapsedTime();
+						const uint64_t elapsedTime = (uint64_t)stopwatch.GetElapsedTime();
 
-							// If this result was faster than a previously fastest result, record this one instead.
-							if((c == 0) || (elapsedTime < gResults[i][sizeType][sortFunction].mTime))
-								gResults[i][sizeType][sortFunction].mTime = elapsedTime;
+						// If this result was faster than a previously fastest result, record this one instead.
+						if ((c == 0) || (elapsedTime < gResults[i][sizeType][sortFunction].mTime))
+							gResults[i][sizeType][sortFunction].mTime = elapsedTime;
 
-							gResults[i][sizeType][sortFunction].mCompareCount = (uint64_t)CompareFunction::nCompareCount;
+						gResults[i][sizeType][sortFunction].mCompareCount = (uint64_t)CompareFunction::nCompareCount;
 
-							VERIFY(eastl::is_sorted(v.begin(), v.end()));
-						}
-
+						VERIFY(eastl::is_sorted(v.begin(), v.end()));
 					} // for each sort function...
 
 				} // for each size type...
@@ -765,16 +791,18 @@ int CompareSortPerformance()
 		delete[] pBuffer;
 
 		// Now print the results.
-		for(int i = 0; i < kRandomizationTypeCount; i++)
+		for (int i = 0; i < kRandomizationTypeCount; i++)
 		{
-			for(size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
+			for (size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
 			{
 				const eastl_size_t size = kSizes[sizeType];
 
-				for(int sortFunction = 0; sortFunction < sf_count; sortFunction++)
+				for (SortFunctionType sortFunction : sortFunctions)
 				{
-					if(sortFunction != sf_radix_sort)
-						sOutput.append_sprintf("%25s, %14s, Size: %6u, Time: %11I64u ticks, Compares: %11I64u\n", GetSortFunctionName(sortFunction), GetRandomizationTypeName(i), (unsigned)size, gResults[i][sizeType][sortFunction].mTime, gResults[i][sizeType][sortFunction].mCompareCount);
+					sOutput.append_sprintf("%25s, %14s, Size: %6u, Time: %11I64u ticks, Compares: %11I64u\n",
+					                       GetSortFunctionName(sortFunction), GetRandomizationTypeName(i),
+					                       (unsigned)size, gResults[i][sizeType][sortFunction].mTime,
+					                       gResults[i][sizeType][sortFunction].mCompareCount);
 				}
 
 				sOutput.append("\n");
@@ -785,33 +813,41 @@ int CompareSortPerformance()
 	}
 
 	{
-		// Do a speed test for the case of slow assignment. 
+		// Do a speed test for the case of slow assignment.
 		// By this we mean to compare sorting speeds when the movement of elements is slow.
-		// Sort functions use element comparison to tell where elements go and use element 
-		// movement to get them there. But some sorting functions accomplish sorting performance by 
+		// Sort functions use element comparison to tell where elements go and use element
+		// movement to get them there. But some sorting functions accomplish sorting performance by
 		// minimizing the amount of movement, some minimize the amount of comparisons, and the
 		// best do a good job of minimizing both.
+		auto sortFunctions = allSortFunctions;
+		// We can't test this radix_sort because what we need isn't exposed.
+		sortFunctions.erase(eastl::remove(sortFunctions.begin(), sortFunctions.end(), sf_radix_sort), sortFunctions.end());
+		// Can't implement this for qsort because the C standard library doesn't expose it.
+		// We could implement it by copying and modifying the source code.
+		sortFunctions.erase(eastl::remove(sortFunctions.begin(), sortFunctions.end(), sf_qsort), sortFunctions.end());
+
 		EA::UnitTest::ReportVerbosity(2, "Sort comparison: Slow assignment speed test\n");
 
-		typedef SlowAssign<int32_t>      ElementType;
+		typedef SlowAssign<int32_t> ElementType;
 		typedef eastl::less<ElementType> CompareFunction;
 
-		eastl::string sOutput; sOutput.set_capacity(100000);
-		ElementType*  pBuffer = new ElementType[kArraySizeMax];
+		eastl::string sOutput;
+		sOutput.set_capacity(100000);
+		ElementType* pBuffer = new ElementType[kArraySizeMax];
 
 		memset(gResults, 0, sizeof(gResults));
 
 		stopwatchGlobal.Restart();
 
-		for(int c = 0; c < kRunCount; c++)
+		for (int c = 0; c < kRunCount; c++)
 		{
-			for(int i = 0; i < kRandomizationTypeCount; i++)
+			for (int i = 0; i < kRandomizationTypeCount; i++)
 			{
-				for(size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
+				for (size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
 				{
 					const eastl_size_t size = kSizes[sizeType];
 
-					for(int sortFunction = 0; sortFunction < sf_count; sortFunction++)
+					for (SortFunctionType sortFunction : sortFunctions)
 					{
 						eastl::vector<ElementType> v(size);
 
@@ -852,7 +888,8 @@ int CompareSortPerformance()
 
 							case sf_merge_sort:
 								stopwatch.Restart();
-								eastl::merge_sort(v.begin(), v.end(), *get_default_allocator((EASTLAllocatorType*)NULL), CompareFunction());
+								eastl::merge_sort(v.begin(), v.end(), *get_default_allocator((EASTLAllocatorType*)NULL),
+								                  CompareFunction());
 								stopwatch.Stop();
 								break;
 
@@ -886,15 +923,6 @@ int CompareSortPerformance()
 								stopwatch.Stop();
 								break;
 
-							case sf_radix_sort:
-								// We can't test this because what we need isn't exposed.
-								break;
-
-							case sf_qsort:
-							// Can't implement this because the C standard library doesn't expose it. 
-							// We could implement it by copying and modifying the source code.
-								break;
-
 							case sf_std_sort:
 								stopwatch.Restart();
 								std::sort(v.begin(), v.end(), std::less<ElementType>());
@@ -902,18 +930,15 @@ int CompareSortPerformance()
 								break;
 						}
 
-						if((sortFunction != sf_radix_sort) && (sortFunction != sf_qsort))
-						{
-							const uint64_t elapsedTime = (uint64_t)stopwatch.GetElapsedTime();
+						const uint64_t elapsedTime = (uint64_t)stopwatch.GetElapsedTime();
 
-							// If this result was faster than a previously fastest result, record this one instead.
-							if((c == 0) || (elapsedTime < gResults[i][sizeType][sortFunction].mTime))
-								gResults[i][sizeType][sortFunction].mTime = elapsedTime;
+						// If this result was faster than a previously fastest result, record this one instead.
+						if ((c == 0) || (elapsedTime < gResults[i][sizeType][sortFunction].mTime))
+							gResults[i][sizeType][sortFunction].mTime = elapsedTime;
 
-							gResults[i][sizeType][sortFunction].mAssignCount = (uint64_t)ElementType::nAssignCount;
+						gResults[i][sizeType][sortFunction].mAssignCount = (uint64_t)ElementType::nAssignCount;
 
-							VERIFY(eastl::is_sorted(v.begin(), v.end()));
-						}
+						VERIFY(eastl::is_sorted(v.begin(), v.end()));
 
 					} // for each sort function...
 
@@ -928,16 +953,18 @@ int CompareSortPerformance()
 		delete[] pBuffer;
 
 		// Now print the results.
-		for(int i = 0; i < kRandomizationTypeCount; i++)
+		for (int i = 0; i < kRandomizationTypeCount; i++)
 		{
-			for(size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
+			for (size_t sizeType = 0; sizeType < EAArrayCount(kSizes); sizeType++)
 			{
 				const eastl_size_t size = kSizes[sizeType];
 
-				for(int sortFunction = 0; sortFunction < sf_count; sortFunction++)
+				for (SortFunctionType sortFunction : sortFunctions)
 				{
-					if((sortFunction != sf_radix_sort) && (sortFunction != sf_qsort)) // qsort doesn't let us count assignments.
-						sOutput.append_sprintf("%25s, %14s, Size: %6u, Time: %11I64u ticks, Assignments: %11I64u\n", GetSortFunctionName(sortFunction), GetRandomizationTypeName(i), (unsigned)size, gResults[i][sizeType][sortFunction].mTime, gResults[i][sizeType][sortFunction].mAssignCount);
+					sOutput.append_sprintf("%25s, %14s, Size: %6u, Time: %11I64u ticks, Assignments: %11I64u\n",
+					                       GetSortFunctionName(sortFunction), GetRandomizationTypeName(i),
+					                       (unsigned)size, gResults[i][sizeType][sortFunction].mTime,
+					                       gResults[i][sizeType][sortFunction].mAssignCount);
 				}
 
 				sOutput.append("\n");
@@ -946,9 +973,9 @@ int CompareSortPerformance()
 		EA::UnitTest::ReportVerbosity(2, "%s\n", sOutput.c_str());
 	}
 
-	#if !defined(EA_DEBUG)
-		EA::UnitTest::SetNormalThreadPriority();
-	#endif
+#if !defined(EA_DEBUG)
+	EA::UnitTest::SetNormalThreadPriority();
+#endif
 
 	return nErrorCount;
 }
@@ -958,17 +985,18 @@ void BenchmarkSort()
 {
 	EASTLTest_Printf("Sort\n");
 
-	EA::UnitTest::RandGenT<uint32_t> rng(12345678); // For debugging sort code we should use 12345678, for normal testing use EA::UnitTest::GetRandSeed().
-	EA::StdC::Stopwatch              stopwatch1(EA::StdC::Stopwatch::kUnitsCPUCycles);
-	EA::StdC::Stopwatch              stopwatch2(EA::StdC::Stopwatch::kUnitsCPUCycles);
+	EA::UnitTest::RandGenT<uint32_t> rng(12345678); // For debugging sort code we should use 12345678, for normal
+	                                                // testing use EA::UnitTest::GetRandSeed().
+	EA::StdC::Stopwatch stopwatch1(EA::StdC::Stopwatch::kUnitsCPUCycles);
+	EA::StdC::Stopwatch stopwatch2(EA::StdC::Stopwatch::kUnitsCPUCycles);
 
-	if(EA::UnitTest::GetVerbosity() >= 3)
+	if (EA::UnitTest::GetVerbosity() >= 3)
 		CompareSortPerformance();
 
 	{ // Exercise some declarations
 		int nErrorCount = 0;
 
-		ValuePair vp1 = { 0, 0 }, vp2 = { 0, 0 };
+		ValuePair vp1 = {0, 0}, vp2 = {0, 0};
 		VPCompare c1, c2;
 
 		VERIFY(c1.operator()(vp1, vp2) == c2.operator()(vp1, vp2));
@@ -979,35 +1007,36 @@ void BenchmarkSort()
 		eastl::vector<uint32_t> intVector(10000);
 		eastl::generate(intVector.begin(), intVector.end(), rng);
 
-		for(int i = 0; i < 2; i++)
+		for (int i = 0; i < 2; i++)
 		{
 			///////////////////////////////
 			// Test quick_sort/vector/ValuePair
 			///////////////////////////////
 
 			StdVectorVP stdVectorVP(intVector.size());
-			EaVectorVP  eaVectorVP (intVector.size());
+			EaVectorVP eaVectorVP(intVector.size());
 
-			for(eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
+			for (eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
 			{
-				const ValuePair vp = { intVector[j], intVector[j] };
+				const ValuePair vp = {intVector[j], intVector[j]};
 				stdVectorVP[j] = vp;
-				eaVectorVP[j]  = vp;
+				eaVectorVP[j] = vp;
 			}
 
 			TestQuickSortStdVP(stopwatch1, stdVectorVP);
-			TestQuickSortEaVP (stopwatch2,  eaVectorVP);
+			TestQuickSortEaVP(stopwatch2, eaVectorVP);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/vector<ValuePair>", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/vector<ValuePair>", stopwatch1.GetUnits(),
+				                     stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
 
 			// Benchmark the sorting of something that is already sorted.
 			TestQuickSortStdVP(stopwatch1, stdVectorVP);
-			TestQuickSortEaVP (stopwatch2,  eaVectorVP);
+			TestQuickSortEaVP(stopwatch2, eaVectorVP);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/vector<ValuePair>/sorted", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
-
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/vector<ValuePair>/sorted", stopwatch1.GetUnits(),
+				                     stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
 
 
 			///////////////////////////////
@@ -1015,27 +1044,28 @@ void BenchmarkSort()
 			///////////////////////////////
 
 			StdVectorInt stdVectorInt(intVector.size());
-			EaVectorInt  eaVectorInt (intVector.size());
+			EaVectorInt eaVectorInt(intVector.size());
 
-			for(eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
+			for (eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
 			{
 				stdVectorInt[j] = intVector[j];
-				eaVectorInt[j]  = intVector[j];
+				eaVectorInt[j] = intVector[j];
 			}
 
 			TestQuickSortStdInt(stopwatch1, stdVectorInt);
-			TestQuickSortEaInt (stopwatch2,  eaVectorInt);
+			TestQuickSortEaInt(stopwatch2, eaVectorInt);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/vector<uint32>", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/vector<uint32>", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(),
+				                     stopwatch2.GetElapsedTime());
 
 			// Benchmark the sorting of something that is already sorted.
 			TestQuickSortStdInt(stopwatch1, stdVectorInt);
-			TestQuickSortEaInt (stopwatch2,  eaVectorInt);
+			TestQuickSortEaInt(stopwatch2, eaVectorInt);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/vector<uint32>/sorted", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
-
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/vector<uint32>/sorted", stopwatch1.GetUnits(),
+				                     stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
 
 
 			///////////////////////////////
@@ -1043,27 +1073,28 @@ void BenchmarkSort()
 			///////////////////////////////
 
 			StdVectorTO stdVectorTO(intVector.size());
-			EaVectorTO  eaVectorTO (intVector.size());
+			EaVectorTO eaVectorTO(intVector.size());
 
-			for(eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
+			for (eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
 			{
 				stdVectorTO[j] = TestObject(intVector[j]);
-				eaVectorTO[j]  = TestObject(intVector[j]);
+				eaVectorTO[j] = TestObject(intVector[j]);
 			}
 
 			TestQuickSortStdTO(stopwatch1, stdVectorTO);
-			TestQuickSortEaTO (stopwatch2,  eaVectorTO);
+			TestQuickSortEaTO(stopwatch2, eaVectorTO);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/vector<TestObject>", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/vector<TestObject>", stopwatch1.GetUnits(),
+				                     stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
 
 			// Benchmark the sorting of something that is already sorted.
 			TestQuickSortStdTO(stopwatch1, stdVectorTO);
-			TestQuickSortEaTO (stopwatch2,  eaVectorTO);
+			TestQuickSortEaTO(stopwatch2, eaVectorTO);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/vector<TestObject>/sorted", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
-
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/vector<TestObject>/sorted", stopwatch1.GetUnits(),
+				                     stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
 
 
 			///////////////////////////////
@@ -1071,29 +1102,26 @@ void BenchmarkSort()
 			///////////////////////////////
 
 			// Reset the values back to the unsorted state.
-			for(eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
+			for (eastl_size_t j = 0, jEnd = intVector.size(); j < jEnd; j++)
 			{
 				stdVectorTO[j] = TestObject(intVector[j]);
-				eaVectorTO[j]  = TestObject(intVector[j]);
+				eaVectorTO[j] = TestObject(intVector[j]);
 			}
 
 			TestQuickSortStdTO(stopwatch1, stdVectorTO);
-			TestQuickSortEaTO (stopwatch2,  eaVectorTO);
+			TestQuickSortEaTO(stopwatch2, eaVectorTO);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/TestObject[]", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/TestObject[]", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(),
+				                     stopwatch2.GetElapsedTime());
 
 			// Benchmark the sorting of something that is already sorted.
 			TestQuickSortStdTO(stopwatch1, stdVectorTO);
-			TestQuickSortEaTO (stopwatch2,  eaVectorTO);
+			TestQuickSortEaTO(stopwatch2, eaVectorTO);
 
-			if(i == 1)
-				Benchmark::AddResult("sort/q_sort/TestObject[]/sorted", stopwatch1.GetUnits(), stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
+			if (i == 1)
+				Benchmark::AddResult("sort/q_sort/TestObject[]/sorted", stopwatch1.GetUnits(),
+				                     stopwatch1.GetElapsedTime(), stopwatch2.GetElapsedTime());
 		}
 	}
 }
-
-
-
-
-


### PR DESCRIPTION
Allowed kSize[] to be updated without requiring manual updates to kSizeCount or kArraySizeMax.
Various sort benchmarks now operate on a vector of sort functions instead of explicitly skipping sort functions in multiple locations.  This change also eliminates the need to handle sort functions in switch statements in order to skip them.

The primary reason for these changes is so that it is easier to benchmark larger array sizes and/or to modify the sort functions that will be benchmarked (since it quickly becomes impractical to benchmark O(n^2) sort functions for larger array sizes).