### PR TITLE
Fixed a bug related to gVerbosityLevel.

### DIFF
--- a/test/packages/EAMain/include/EAMain/EAEntryPointMain.inl
+++ b/test/packages/EAMain/include/EAMain/EAEntryPointMain.inl
@@ -11,6 +11,11 @@ namespace EA
 {
     namespace EAMain
     {
+		namespace Internal
+		{
+			unsigned gVerbosityLevel = 0;	
+		}
+
 		void PlatformStartup() {}
 		void PlatformShutdown(int nErrorCount) 
 		{

--- a/test/packages/EAMain/include/EAMain/EAMain.h
+++ b/test/packages/EAMain/include/EAMain/EAMain.h
@@ -11,7 +11,7 @@ namespace EA
     {
 		namespace Internal
 		{
-			static unsigned gVerbosityLevel = 0;	
+			extern unsigned gVerbosityLevel;
 		};
 
         typedef void (*ReportFunction)(const char8_t*);


### PR DESCRIPTION
The variable was previously declared as being static which meant it could take on different values in different translation units.  The issue was resolved by making the variable extern and defining it in EAEntryPointMain.inl (which is assumed to be included exactly once for a program).