### PR TITLE
Fix constexpr specifier for integral_constant

### DIFF
--- a/include/EASTL/type_traits.h
+++ b/include/EASTL/type_traits.h
@@ -261,7 +261,7 @@ namespace eastl
 	template <typename T, T v>
 	struct integral_constant
 	{
-		static const T value = v;
+		static EA_CONSTEXPR T value = v;
 		typedef T value_type;
 		typedef integral_constant<T, v> type;
 

--- a/test/source/TestTypeTraits.cpp
+++ b/test/source/TestTypeTraits.cpp
@@ -454,6 +454,7 @@ typedef void (*FunctionVoidVoidPtr)();
 namespace
 {
 	const eastl::string gEmptyStringInstance("");
+	const eastl::integral_constant<int*, nullptr> gIntNullptrConstant;
 }
 
 int TestTypeTraits()


### PR DESCRIPTION
integral_constant<T, v>::value should be constexpr.

This fix use of constexpr non-integral constants, e.g.:
type_traits.h:264:18: error: `constexpr` needed
for in-class initialization of static data member
`int* const eastl::integral_constant<int*, 0u>::value`
of non-integral type [-fpermissive]
