### PR TITLE
Adding "inline" to get(...) functions for TupleImpl

### DIFF
--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -396,42 +396,42 @@ struct TupleImpl<integer_sequence<size_t, Indices...>, Ts...> : public TupleLeaf
 };
 
 template <size_t I, typename Indices, typename... Ts>
-tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(TupleImpl<Indices, Ts...>& t)
+inline tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(TupleImpl<Indices, Ts...>& t)
 {
 	typedef tuple_element_t<I, TupleImpl<Indices, Ts...>> Type;
 	return static_cast<Internal::TupleLeaf<I, Type>&>(t).getInternal();
 }
 
 template <size_t I, typename Indices, typename... Ts>
-const tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices, Ts...>& t)
+inline const tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices, Ts...>& t)
 {
 	typedef tuple_element_t<I, TupleImpl<Indices, Ts...>> Type;
 	return static_cast<const Internal::TupleLeaf<I, Type>&>(t).getInternal();
 }
 
 template <size_t I, typename Indices, typename... Ts>
-tuple_element_t<I, TupleImpl<Indices, Ts...>>&& get(TupleImpl<Indices, Ts...>&& t)
+inline tuple_element_t<I, TupleImpl<Indices, Ts...>>&& get(TupleImpl<Indices, Ts...>&& t)
 {
 	typedef tuple_element_t<I, TupleImpl<Indices, Ts...>> Type;
 	return static_cast<Type&&>(static_cast<Internal::TupleLeaf<I, Type>&>(t).getInternal());
 }
 
 template <typename T, typename Indices, typename... Ts>
-T& get(TupleImpl<Indices, Ts...>& t)
+inline T& get(TupleImpl<Indices, Ts...>& t)
 {
 	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
 	return static_cast<Internal::TupleLeaf<Index::index, T>&>(t).getInternal();
 }
 
 template <typename T, typename Indices, typename... Ts>
-const T& get(const TupleImpl<Indices, Ts...>& t)
+inline const T& get(const TupleImpl<Indices, Ts...>& t)
 {
 	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
 	return static_cast<const Internal::TupleLeaf<Index::index, T>&>(t).getInternal();
 }
 
 template <typename T, typename Indices, typename... Ts>
-T&& get(TupleImpl<Indices, Ts...>&& t)
+inline T&& get(TupleImpl<Indices, Ts...>&& t)
 {
 	typedef tuple_index<T, TupleImpl<Indices, Ts...>> Index;
 	return static_cast<T&&>(static_cast<Internal::TupleLeaf<Index::index, T>&>(t).getInternal());


### PR DESCRIPTION
The lack of inline on these functions was causing some performance problems in some situations where tuple is heavily utilized, often resulting in having to change Cmake's "RelWithDebugInfo" generated configuration in order to get accurate performance data.

e.g. a simple loop over a vector of tuples such as...
```
	int numTupleBools = 0;	
	for (auto& iter : tupleVec)
	{
		numTupleBools += get<0>(iter) ? 1 : 0;
	}
```
...resulted in nearly twice the number of instructions and execution time, due to having to call eastl::Internal::get(...) on each iteration, instead of accessing the data in the tuple directly.

Note that both of these functions callers and callees have the inline tag, and when "any suitable" inlining is enabled, these functions get inlined away in almost all cases - after all, it just acts as an intermediary between TupleImpl and one of its TupleLeaf's.