### PR TITLE
Adding test cases and fixes around move-only/ref types for Tuples

### DIFF
--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -238,6 +238,10 @@ public:
 	{
 	}
 
+	explicit TupleLeaf(ValueType& t) : mValue(t)
+	{
+	}
+
 	template <typename T>
 	explicit TupleLeaf(const TupleLeaf<I, T>& t)
 		: mValue(t.getInternal())

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -264,6 +264,15 @@ int TestTuple()
 		EATEST_VERIFY(get<0>(aTupleWithMoveOnlyMember).mVal == 1);
 		get<0>(aTupleWithMoveOnlyMember) = MoveOnlyType(2);
 		EATEST_VERIFY(get<0>(aTupleWithMoveOnlyMember).mVal == 2);
+
+		tuple<const MoveOnlyType&> aTupleWithRefToMoveOnlyMember(aTupleWithMoveOnlyMember);
+		EATEST_VERIFY(get<0>(aTupleWithRefToMoveOnlyMember).mVal == 2);
+
+		tuple<const MoveOnlyType&> aTupleWithConstRefToGetMoveOnly(get<0>(aTupleWithMoveOnlyMember));
+		EATEST_VERIFY(get<0>(aTupleWithConstRefToGetMoveOnly).mVal == 2);
+
+		tuple<MoveOnlyType&> aTupleWithRefToGetMoveOnly(get<0>(aTupleWithMoveOnlyMember));
+		EATEST_VERIFY(get<0>(aTupleWithRefToGetMoveOnly).mVal == 2);
 	}
 
 	{


### PR DESCRIPTION
Additional test cases now check that tuples with move-only ref types now compile properly, instead of, apparently, finding a template deduction that attempted an implicit cast to value-type.

Also, the missing cast of a ValueType& for the TupleLeaf ref specialization was added to satisfy the new test cases.

Fixes #180 