### PR TITLE
Adding "bonus" headers to files included in EASTL project during cmake generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ add_definitions(-DEASTL_OPENSOURCE=1)
 #-------------------------------------------------------------------------------------------
 # Library definition
 #-------------------------------------------------------------------------------------------
-file(GLOB EASTL_SOURCES "source/*.cpp" "include/EASTL/*.h")
+file(GLOB EASTL_SOURCES "source/*.cpp" "include/EASTL/*.h" "include/EASTL/bonus/*.h")
 add_library(EASTL ${EASTL_SOURCES})
 include_directories("include")
 


### PR DESCRIPTION
Noticed that after moving some headers to 'bonus' that the files were no longer referenced by the EASTL project, due to cmake not including them in the list of sources.

Note that changing the FILE command to use "GLOB_RECURSE" would be done as well, if it was desirable to nab the "internal" headers, but IME I've only ever walked those files as a part of going through 'go to definitions' of files in .../eastl/ or .../eastl/bonus/, and almost never opened up those files directly, as direct project inclusion permits.