### PR TITLE
Adding tests and fixes for, e.g., comparison of tuples w/ non-const refs

### DIFF
--- a/include/EASTL/internal/tuple_fwd_decls.h
+++ b/include/EASTL/internal/tuple_fwd_decls.h
@@ -23,12 +23,20 @@ namespace eastl
 	template <size_t I, typename Tuple>
 	using tuple_element_t = typename tuple_element<I, Tuple>::type;
 
+	// const typename for tuple_element_t, for when tuple or TupleImpl cannot itself be const
+	template <size_t I, typename Tuple>
+	using const_tuple_element_t = typename conditional<
+						is_lvalue_reference<tuple_element_t<I, Tuple>>::value,
+							 add_lvalue_reference_t<const remove_reference_t<tuple_element_t<I, Tuple>>>,
+							 const tuple_element_t<I, Tuple>
+						>::type;
+
 	// get
 	template <size_t I, typename... Ts_>
 	tuple_element_t<I, tuple<Ts_...>>& get(tuple<Ts_...>& t);
 
 	template <size_t I, typename... Ts_>
-	const tuple_element_t<I, tuple<Ts_...>>& get(const tuple<Ts_...>& t);
+	const_tuple_element_t<I, tuple<Ts_...>>& get(const tuple<Ts_...>& t);
 
 	template <size_t I, typename... Ts_>
 	tuple_element_t<I, tuple<Ts_...>>&& get(tuple<Ts_...>&& t);

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -348,7 +348,7 @@ template <size_t I, typename Indices, typename... Ts>
 tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(TupleImpl<Indices, Ts...>& t);
 
 template <size_t I, typename Indices, typename... Ts>
-const tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices, Ts...>& t);
+const_tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices, Ts...>& t);
 
 template <size_t I, typename Indices, typename... Ts>
 tuple_element_t<I, TupleImpl<Indices, Ts...>>&& get(TupleImpl<Indices, Ts...>&& t);
@@ -407,7 +407,7 @@ inline tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(TupleImpl<Indices, Ts.
 }
 
 template <size_t I, typename Indices, typename... Ts>
-inline const tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices, Ts...>& t)
+inline const_tuple_element_t<I, TupleImpl<Indices, Ts...>>& get(const TupleImpl<Indices, Ts...>& t)
 {
 	typedef tuple_element_t<I, TupleImpl<Indices, Ts...>> Type;
 	return static_cast<const Internal::TupleLeaf<I, Type>&>(t).getInternal();
@@ -731,7 +731,7 @@ private:
 	friend tuple_element_t<I, tuple<Ts_...>>& get(tuple<Ts_...>& t);
 
 	template <size_t I, typename... Ts_>
-	friend const tuple_element_t<I, tuple<Ts_...>>& get(const tuple<Ts_...>& t);
+	friend const_tuple_element_t<I, tuple<Ts_...>>& get(const tuple<Ts_...>& t);
 
 	template <size_t I, typename... Ts_>
 	friend tuple_element_t<I, tuple<Ts_...>>&& get(tuple<Ts_...>&& t);
@@ -760,7 +760,7 @@ inline tuple_element_t<I, tuple<Ts...>>& get(tuple<Ts...>& t)
 }
 
 template <size_t I, typename... Ts>
-inline const tuple_element_t<I, tuple<Ts...>>& get(const tuple<Ts...>& t)
+inline const_tuple_element_t<I, tuple<Ts...>>& get(const tuple<Ts...>& t)
 {
 	return get<I>(t.mImpl);
 }

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -248,6 +248,18 @@ int TestTuple()
 		EATEST_VERIFY(lesserTuple < greaterTuple && !(greaterTuple < lesserTuple) && greaterTuple > lesserTuple &&
 					  !(lesserTuple > greaterTuple));
 
+		tuple<int, float, TestObject> valTup(2, 2.0f, TestObject(2));
+		tuple<int&, float&, TestObject&> refTup(valTup);
+		tuple<const int&, const float&, const TestObject&> constRefTup(valTup);
+
+		EATEST_VERIFY(get<0>(refTup) == get<0>(valTup));
+		EATEST_VERIFY(get<1>(refTup) == get<1>(valTup));
+		EATEST_VERIFY(refTup == valTup);
+		EATEST_VERIFY(get<0>(refTup) == get<0>(constRefTup));
+		EATEST_VERIFY(get<1>(refTup) == get<1>(constRefTup));
+		EATEST_VERIFY(constRefTup == valTup);
+		EATEST_VERIFY(constRefTup == refTup);
+
 		// swap
 		swap(lesserTuple, greaterTuple);
 		EATEST_VERIFY(get<2>(lesserTuple) == 4 && get<2>(greaterTuple) == 3);


### PR DESCRIPTION
`const` qualifier on `const tuple_element_t<I, TupleImpl<Indices, Ts...>>&` gets dropped when Ts is an lvalue ref. In this case, the only source of 'const-ness' on `tuple_element_t` comes from being baked into the source type. This means for non-const lvalue refs, the return type just becomes `Ts&`, but `getInternal` will attempt to return a const-ref value, and fail to compile because we cannot remove the const qualifier.

This problem was discovered when trying to use a comparison operator on a tuple containing non-const refs: one of the functions specifically coerces the input parameters to be `const tuple<Ts...>&`, and attempted to then call `get<...>(const tuple<Ts...>&)` on it. This was avoided until a recent experiment because the object used for the input was not strictly const, or did not contain non-const ref types. 

Attempted alternatives:

- Doing a `const_cast` to coerce the return from `getInternal` to not be `const`, and then have it be switched back to `const` or not as needed (for lvalue-refs, or just value types) works. It works, but does not fix the problem of the return type simply being wrong.

- Setting `tupleImpl` to be `const`, i.e. `tuple_element_t<I, const TupleImpl<Indices, Ts...>`, does get the return type correct, but elsewhere the compiler attempts to instantiate the types for the function when evaluating overloads for `tuple`'s that include move-only datatypes, and compilation fails because of attempts to add const to an rvalue object. Doesn't work.

- Setting `Ts` itself to be `const` in the `tuple_element_t` declarations failed because the `const` was still getting stripped off at some point. Doesn't work.

- Other transformations to how `tuple_element_t` devolves into a type - even using `typename tuple_element<...>` directly just resulted in a similar scenario. Trying to manually tack on `const` to the type in question after the fact, when we're dealing with changing the ref to be const and not changing the _type of_ the ref to be const, simply didn't work.

For more information: https://en.cppreference.com/w/cpp/language/reference

> Reference types cannot be cv-qualified at the top level; there is no syntax for that in declaration, and if a qualification is introduced through a typedef, decltype, or template type argument, it is ignored.