### PR TITLE
natvis change for strings and unique_ptr

### DIFF
--- a/doc/EASTL.natvis
+++ b/doc/EASTL.natvis
@@ -21,6 +21,13 @@
 	</Expand>
 </Type>
 
+<Type Name="eastl::unique_ptr&lt;*&gt;">
+	<DisplayString>{mPair.mFirst}</DisplayString>
+	<Expand>
+		<Item Name="[pointer]">mPair.mFirst</Item>
+	</Expand>
+</Type>
+
 <Type Name="eastl::weak_ptr&lt;*&gt;">
 	<DisplayString>{((mpRefCount &amp;&amp; mpRefCount-&gt;mRefCount) ? mpValue : nullptr)}</DisplayString>
 	<Expand>
@@ -47,34 +54,34 @@
 </Type>
 
 <Type Name="eastl::basic_string&lt;char,*&gt;">
-	<DisplayString>{mPair.mFirst.heap.mpBegin,s}</DisplayString>
+	<DisplayString Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">{mPair.mFirst.heap.mpBegin,s}</DisplayString>
+    <DisplayString Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">{mPair.mFirst.sso.mData,s}</DisplayString>
 	<Expand>
-		<Item Name="length"   Condition="!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mnSize</Item>
-		<Item Name="capacity" Condition="!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">(mPair.mFirst.heap.mnCapacity
-		&amp; ~kHeapMask)</Item>
-		<Item Name="value"    Condition="!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mpBegin,sb</Item>
+		<Item Name="[length]"  Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mnSize</Item>
+		<Item Name="[capacity]" Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">(mPair.mFirst.heap.mnCapacity &amp; ~kHeapMask)</Item>
+		<Item Name="[value]" Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mpBegin,sb</Item>
 
-		<Item Name="length"   Condition="!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mnSize</Item>
-		<Item Name="capacity" Condition="!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">SSOLayout::SSO_CAPACITY</Item>
-		<Item Name="value"    Condition="!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mData,sb</Item>
+		<Item Name="[length]"   Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mSizeField.mnSize</Item>
+		<Item Name="[capacity]" Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">SSOLayout::SSO_CAPACITY</Item>
+		<Item Name="[value]"    Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mData,sb</Item>
 
-		<Item Name="uses heap">!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)</Item>
+		<Item Name="[uses heap]">!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)</Item>
 	</Expand>
 </Type>
 
 <Type Name="eastl::basic_string&lt;wchar_t,*&gt;">
-	<DisplayString>{mPair.mFirst.heap.mpBegin,su}</DisplayString>
+    <DisplayString Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">{mPair.mFirst.heap.mpBegin,su}</DisplayString>
+    <DisplayString Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">{mPair.mFirst.sso.mData,su}</DisplayString>
 	<Expand>
-		<Item Name="length"   Condition="!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mnSize</Item>
-		<Item Name="capacity" Condition="!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">(mPair.mFirst.heap.mnCapacity
-		&amp; ~kHeapMask)</Item>
-		<Item Name="value"    Condition="!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mpBegin,sb</Item>
+		<Item Name="[length]" Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mnSize</Item>
+		<Item Name="[capacity]" Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">(mPair.mFirst.heap.mnCapacity &amp; ~kHeapMask)</Item>
+		<Item Name="[value]" Condition="!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.heap.mpBegin,sub</Item>
 
-		<Item Name="length"   Condition="!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mnSize</Item>
-		<Item Name="capacity" Condition="!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">SSOLayout::SSO_CAPACITY</Item>
-		<Item Name="value"    Condition="!(mPair.mFirst.sso.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mData,sb</Item>
+		<Item Name="[length]" Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mSizeField.mnSize</Item>
+		<Item Name="[capacity]" Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">SSOLayout::SSO_CAPACITY</Item>
+		<Item Name="[value]" Condition="!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)">mPair.mFirst.sso.mData,sub</Item>
 
-		<Item Name="uses heap">!!(mPair.mFirst.sso.mnSize &amp; kSSOMask)</Item>
+		<Item Name="[uses heap]">!!(mPair.mFirst.sso.mSizeField.mnSize &amp; kSSOMask)</Item>
 	</Expand>
 </Type>
 


### PR DESCRIPTION
updated natvis with @ivalylo's suggested changes for string types
enclosed string properties in brackets to match VS std displays
changed wchar_t properties to be formatted as 'sub' instead of 'sb'
added debugger display for unique_ptr

#173 