### PR TITLE
Updating the fixed_pool impl of swap to use Move 

### DIFF
--- a/include/EASTL/internal/fixed_pool.h
+++ b/include/EASTL/internal/fixed_pool.h
@@ -1590,9 +1590,9 @@ namespace eastl
 	public:
 		static void swap(Container& a, Container& b)
 		{
-			const Container temp(a); // Can't use global swap because that could
-			a = b;                   // itself call this swap function in return.
-			b = temp;
+			Container temp(move(a)); // Can't use global swap because that could
+			a = move(b);             // itself call this swap function in return.
+			b = move(temp);
 		}
 	};
 
@@ -1608,9 +1608,9 @@ namespace eastl
 
 			if(pMemory)
 			{
-				Container* const pTemp = ::new(pMemory) Container(a);
-				a = b;
-				b = *pTemp;
+				Container* pTemp = ::new(pMemory) Container(move(a));
+				a = move(b);
+				b = move(*pTemp);
 
 				pTemp->~Container();
 				allocator.deallocate(pMemory, sizeof(a));

--- a/include/EASTL/internal/fixed_pool.h
+++ b/include/EASTL/internal/fixed_pool.h
@@ -1590,9 +1590,9 @@ namespace eastl
 	public:
 		static void swap(Container& a, Container& b)
 		{
-			Container temp(move(a)); // Can't use global swap because that could
-			a = move(b);             // itself call this swap function in return.
-			b = move(temp);
+			Container temp(EASTL_MOVE(a)); // Can't use global swap because that could
+			a = EASTL_MOVE(b);             // itself call this swap function in return.
+			b = EASTL_MOVE(temp);
 		}
 	};
 
@@ -1608,9 +1608,9 @@ namespace eastl
 
 			if(pMemory)
 			{
-				Container* pTemp = ::new(pMemory) Container(move(a));
-				a = move(b);
-				b = move(*pTemp);
+				Container* pTemp = ::new(pMemory) Container(EASTL_MOVE(a));
+				a = EASTL_MOVE(b);
+				b = EASTL_MOVE(*pTemp);
 
 				pTemp->~Container();
 				allocator.deallocate(pMemory, sizeof(a));

--- a/test/source/TestFixedVector.cpp
+++ b/test/source/TestFixedVector.cpp
@@ -515,10 +515,19 @@ int TestFixedVector()
 		}
 		EATEST_VERIFY(fvmv2.validate());
 		
-		fixed_vector<unique_ptr<unsigned int>, FV_SIZE> fv = eastl::move(fvmv2); // Test move copy constructor
+		swap(fvmv1, fvmv2); // Test swap with move-only objects
 		for (unsigned int i = 0; i < FV_SIZE; ++i)
 		{
+			EATEST_VERIFY(*fvmv1[i] == i);
 			EATEST_VERIFY(!fvmv2[i]);
+		}
+		EATEST_VERIFY(fvmv1.validate());
+		EATEST_VERIFY(fvmv2.validate());
+
+		fixed_vector<unique_ptr<unsigned int>, FV_SIZE> fv = eastl::move(fvmv1); // Test move copy constructor
+		for (unsigned int i = 0; i < FV_SIZE; ++i)
+		{
+			EATEST_VERIFY(!fvmv1[i]);
 			EATEST_VERIFY(*fv[i] == i);
 		}
 		EATEST_VERIFY(fv.validate());


### PR DESCRIPTION
While working on some stuff, I noticed that swap() on fixed_vectors with move-only types did not function. This was because the fixed_swap implementation still operated on copy-construction and not move-construction. This update brings the fixed_swap impl back in line to match the functionality in the swap function in utility.h.