### PR TITLE
Fix basic_string_view sub-string based basic_string constructor

### DIFF
--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -493,18 +493,8 @@ namespace eastl
 		basic_string(this_type&& x) EA_NOEXCEPT;
 		basic_string(this_type&& x, const allocator_type& allocator);
 
-		explicit basic_string(const view_type& sv, const allocator_type& alloc = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR)
-		    : basic_string(sv.data(), sv.size(), alloc)
-		{
-		}
-
-		basic_string(const view_type& sv,
-		             size_type pos,
-		             size_type n,
-		             const allocator_type& alloc = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR)
-		    : basic_string(sv.substr(pos, n), alloc)
-		{
-		}
+		explicit basic_string(const view_type& sv, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
+		basic_string(const view_type& sv, size_type position, size_type n, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
 
 		template <typename OtherCharType>
 		basic_string(CtorConvert, const OtherCharType* p, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
@@ -752,7 +742,7 @@ namespace eastl
 		void        RangeInitialize(const value_type* pBegin);
 		void        SizeInitialize(size_type n, value_type c);
 
-		bool        IsSSO() const EA_NOEXCEPT; 
+		bool        IsSSO() const EA_NOEXCEPT;
 
 		void        ThrowLengthException() const;
 		void        ThrowRangeException() const;
@@ -855,6 +845,22 @@ namespace eastl
 		: mPair(allocator)
 	{
 		RangeInitialize(p, p + n);
+	}
+
+
+	template <typename T, typename Allocator>
+    inline basic_string<T, Allocator>::basic_string(const view_type& sv, const allocator_type& allocator)
+		: basic_string(sv.data(), sv.size(), allocator)
+	{
+
+	}
+
+
+	template <typename T, typename Allocator>
+	inline basic_string<T, Allocator>::basic_string(const view_type& sv, size_type position, size_type n, const allocator_type& allocator)
+		: basic_string(sv.substr(position, n), allocator)
+	{
+
 	}
 
 
@@ -1811,7 +1817,7 @@ namespace eastl
 		else if(nReturnValue < 0) // If vsnprintf is non-C99-standard
 		{
 			// In this case we either have C89 extension behaviour or C99 behaviour.
-			size_type n = eastl::max_alt((size_type)(SSOLayout::SSO_CAPACITY - 1), (size_type)(nInitialSize * 2)); 
+			size_type n = eastl::max_alt((size_type)(SSOLayout::SSO_CAPACITY - 1), (size_type)(nInitialSize * 2));
 
 			for(; (nReturnValue < 0) && (n < 1000000); n *= 2)
 			{

--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -502,7 +502,7 @@ namespace eastl
 		             size_type pos,
 		             size_type n,
 		             const allocator_type& alloc = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR)
-		    : basic_string(sv.substr(pos, n), n, alloc)
+		    : basic_string(sv.substr(pos, n), alloc)
 		{
 		}
 

--- a/test/source/TestString.inl
+++ b/test/source/TestString.inl
@@ -21,7 +21,7 @@ int TEST_STRING_NAME()
 	struct Failocator
 	{
 		Failocator() = default;
-		Failocator(const char*) {} 
+		Failocator(const char*) {}
 
 		void* allocate(size_t n) { EA_FAIL(); return nullptr; }
 		void deallocate(void* p, size_t) { EA_FAIL(); }
@@ -30,7 +30,7 @@ int TEST_STRING_NAME()
 	#if defined(EA_PLATFORM_ANDROID)
 		EA_DISABLE_CLANG_WARNING(-Wunknown-warning-option)  // warning: disable unknown warning suppression pragmas
 		EA_DISABLE_CLANG_WARNING(-Wunknown-pragmas)         // warning: disable unknown warning suppression pragmas
-		EA_DISABLE_CLANG_WARNING(-Winherited-variadic-ctor) // warning: inheriting constructor does not inherit ellipsis 
+		EA_DISABLE_CLANG_WARNING(-Winherited-variadic-ctor) // warning: inheriting constructor does not inherit ellipsis
 	#endif
 
 	struct SSOStringType : public StringType
@@ -51,7 +51,7 @@ int TEST_STRING_NAME()
 		EA_RESTORE_CLANG_WARNING()
 		EA_RESTORE_CLANG_WARNING()
 	#endif
-	
+
 	// SSO (short string optimization) tests
 	{
 		{
@@ -151,7 +151,7 @@ int TEST_STRING_NAME()
 	}
 
 	// explicit basic_string(const allocator_type& allocator);
-	{ 
+	{
 		typename StringType::allocator_type alloc;
 		StringType str(alloc);
 		VERIFY(str.validate());
@@ -190,7 +190,7 @@ int TEST_STRING_NAME()
 		VERIFY(str3 == LITERAL("z"));
 		VERIFY(str3.size() == 1);
 		VERIFY(str3.length() == 1);
-		VERIFY(str3.capacity() >= 1); // SSO buffer size 
+		VERIFY(str3.capacity() >= 1); // SSO buffer size
 
 		VERIFY(str1.validate());
 		VERIFY(str2.validate());
@@ -198,7 +198,7 @@ int TEST_STRING_NAME()
 	}
 
 	// EASTL_STRING_EXPLICIT basic_string(const value_type* p, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
-	{ 
+	{
 		auto* pLiteral = LITERAL("abcdefghijklmnopqrstuvwxyz");
 		StringType str(pLiteral);
 		VERIFY(str == pLiteral);
@@ -325,6 +325,30 @@ int TEST_STRING_NAME()
 	#endif
 	}
 
+	// basic_string(const view_type& sv, const allocator_type& allocator);
+	// basic_string(const view_type& sv, size_type position, size_type n, const allocator_type& allocator);
+	{
+		{  // test string_view
+			typename StringType::view_type sv(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+            StringType str(sv);
+
+			VERIFY(str == LITERAL("abcdefghijklmnopqrstuvwxyz"));
+			VERIFY(!str.empty());
+			VERIFY(str.length() == 26);
+			VERIFY(str.size() == 26);
+			VERIFY(str.validate());
+		}
+		{  // test string_view substring
+			typename StringType::view_type sv(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+            StringType str(sv, 2, 22);
+
+			VERIFY(str == LITERAL("cdefghijklmnopqrstuvwx"));
+			VERIFY(!str.empty());
+			VERIFY(str.length() == 22);
+			VERIFY(str.size() == 22);
+			VERIFY(str.validate());
+		}
+	}
 
 	// template <typename OtherCharType>
 	// basic_string(CtorConvert, const OtherCharType* p, const allocator_type& allocator = EASTL_BASIC_STRING_DEFAULT_ALLOCATOR);
@@ -527,7 +551,7 @@ int TEST_STRING_NAME()
 	#endif
 	}
 
-	//     this_type& operator=(value_type* p); 
+	//     this_type& operator=(value_type* p);
 	//
 	//     template <typename OtherCharType>
 	//     this_type& operator=(const OtherCharType* p);
@@ -622,7 +646,7 @@ int TEST_STRING_NAME()
 
 		VERIFY(str1 != LITERAL("abcdefghijklmnopqrstuvwxyz"));
 		VERIFY(str2 == LITERAL("abcdefghijklmnopqrstuvwxyz"));
-		
+
 		VERIFY(str1.empty());
 		VERIFY(!str2.empty());
 
@@ -644,7 +668,7 @@ int TEST_STRING_NAME()
 
 		VERIFY(str1 == LITERAL("abcdefghijklmnopqrstuvwxyz"));
 		VERIFY(str2 == LITERAL("abcdefghijklmnopqrstuvwxyz"));
-		
+
 		VERIFY(!str1.empty());
 		VERIFY(!str2.empty());
 
@@ -720,7 +744,7 @@ int TEST_STRING_NAME()
 
 		VERIFY(str1 != LITERAL("abcdefghijklmnopqrstuvwxyz"));
 		VERIFY(str2 == LITERAL("abcdefghijklmnopqrstuvwxyz"));
-		
+
 		VERIFY(str1.empty());
 		VERIFY(!str2.empty());
 
@@ -882,7 +906,7 @@ int TEST_STRING_NAME()
 
 	}
 
-	// iterator       end() EA_NOEXCEPT;       
+	// iterator       end() EA_NOEXCEPT;
 	// const_iterator end() const EA_NOEXCEPT;
 	// const_iterator cend() const EA_NOEXCEPT;
 	{
@@ -934,7 +958,7 @@ int TEST_STRING_NAME()
 	}
 
 	// bool empty() const EA_NOEXCEPT;
-	// size_type size() const EA_NOEXCEPT; 
+	// size_type size() const EA_NOEXCEPT;
 	// size_type length() const EA_NOEXCEPT;
 	// size_type capacity() const EA_NOEXCEPT;
 	// void resize(size_type n, value_type c);
@@ -1151,7 +1175,7 @@ int TEST_STRING_NAME()
 
 		auto* pData = str.data();
 		auto* pCStr = str.c_str();
-		
+
 		VERIFY(pData != nullptr);
 		VERIFY(pCStr != nullptr);
 		VERIFY(pData == pCStr);
@@ -1202,7 +1226,7 @@ int TEST_STRING_NAME()
 		str1 += LITERAL("456");
 		str1 += LITERAL('7');
 
-		VERIFY(str1 == LITERAL("abcdefghijklmnopqrstuvwxyz1234567")); 
+		VERIFY(str1 == LITERAL("abcdefghijklmnopqrstuvwxyz1234567"));
 	}
 
 	// this_type& append(const this_type& x);
@@ -1389,13 +1413,13 @@ int TEST_STRING_NAME()
 	{
 		StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
 
-		str.insert((typename StringType::size_type)0, (typename StringType::size_type)1, LITERAL('1'));   // todo: elminiate the cast to disambiguate 
+		str.insert((typename StringType::size_type)0, (typename StringType::size_type)1, LITERAL('1'));   // todo: elminiate the cast to disambiguate
 		VERIFY(str == LITERAL("1abcdefghijklmnopqrstuvwxyz"));
 
-		str.insert(2, LITERAL("234")); 
+		str.insert(2, LITERAL("234"));
 		VERIFY(str == LITERAL("1a234bcdefghijklmnopqrstuvwxyz"));
 
-		str.insert(15, StringType(LITERAL("567"))); 
+		str.insert(15, StringType(LITERAL("567")));
 		VERIFY(str == LITERAL("1a234bcdefghijk567lmnopqrstuvwxyz"));
 
 		str.insert(30, StringType(LITERAL(" is an example of a substring")), 1, 14);
@@ -1501,7 +1525,7 @@ int TEST_STRING_NAME()
 	// pointer detach() EA_NOEXCEPT;
 	{
 		{
-			// Heap 
+			// Heap
 			auto* pLiteral = LITERAL("abcdefghijklmnopqrstuvwxyz");
 			StringType str(pLiteral);
 			const auto sz = str.size() + 1;  // +1 for null-terminator
@@ -1514,11 +1538,11 @@ int TEST_STRING_NAME()
 			VERIFY(str.empty());
 			VERIFY(str.size() == 0);
 
-			str.get_allocator().deallocate(pDetach, sz); 
+			str.get_allocator().deallocate(pDetach, sz);
 		}
 
 		{
-			// SSO 
+			// SSO
 			auto* pLiteral = LITERAL("a");
 			StringType str(pLiteral);
 			const auto sz = str.size() + 1;  // +1 for null-terminator
@@ -1531,7 +1555,7 @@ int TEST_STRING_NAME()
 			VERIFY(str.empty());
 			VERIFY(str.size() == 0);
 
-			str.get_allocator().deallocate(pDetach, sz); 
+			str.get_allocator().deallocate(pDetach, sz);
 		}
 
 		{
@@ -1548,7 +1572,7 @@ int TEST_STRING_NAME()
 			VERIFY(str.empty());
 			VERIFY(str.size() == 0);
 
-			str.get_allocator().deallocate(pDetach, sz); 
+			str.get_allocator().deallocate(pDetach, sz);
 		}
 
 		{
@@ -1563,7 +1587,7 @@ int TEST_STRING_NAME()
 			VERIFY(str.empty());
 			VERIFY(str.size() == 0);
 
-			str.get_allocator().deallocate(pDetach, sz); 
+			str.get_allocator().deallocate(pDetach, sz);
 		}
 	}
 
@@ -1603,7 +1627,7 @@ int TEST_STRING_NAME()
 		VERIFY(EA::StdC::Memcmp(buf, LITERAL("klmnopqrst"), 10) == 0);
 	}
 
-	// size_type find(const this_type& x, size_type position = 0) const EA_NOEXCEPT; 
+	// size_type find(const this_type& x, size_type position = 0) const EA_NOEXCEPT;
 	// size_type find(const value_type* p, size_type position = 0) const;
 	// size_type find(const value_type* p, size_type position, size_type n) const;
 	// size_type find(value_type c, size_type position = 0) const EA_NOEXCEPT;
@@ -1627,7 +1651,7 @@ int TEST_STRING_NAME()
 		VERIFY(str.find(LITERAL('1'), 2) == StringType::npos);
 	}
 
-	// size_type rfind(const this_type& x, size_type position = npos) const EA_NOEXCEPT; 
+	// size_type rfind(const this_type& x, size_type position = npos) const EA_NOEXCEPT;
 	// size_type rfind(const value_type* p, size_type position = npos) const;
 	// size_type rfind(const value_type* p, size_type position, size_type n) const;
 	// size_type rfind(value_type c, size_type position = npos) const EA_NOEXCEPT;
@@ -1694,9 +1718,9 @@ int TEST_STRING_NAME()
 
 		VERIFY(str.find_first_not_of(StringType(LITERAL("abcdfg"))) == 18);
 		VERIFY(str.find_first_not_of(LITERAL("abcdfg")) == 18);
-		// VERIFY(str.find_first_not_of(LITERAL("abcdfg"), 2, 2) == 0);   // todo:  FIX ME 
-		// VERIFY(str.find_first_not_of(LITERAL("abcdfg"), 0, 2) == 10);  // todo:  FIX ME 
-		VERIFY(str.find_first_not_of(LITERAL('a')) == 5);  
+		// VERIFY(str.find_first_not_of(LITERAL("abcdfg"), 2, 2) == 0);   // todo:  FIX ME
+		// VERIFY(str.find_first_not_of(LITERAL("abcdfg"), 0, 2) == 10);  // todo:  FIX ME
+		VERIFY(str.find_first_not_of(LITERAL('a')) == 5);
 	}
 
 	// size_type find_last_not_of(const this_type& x,  size_type position = npos) const EA_NOEXCEPT;
@@ -1710,9 +1734,9 @@ int TEST_STRING_NAME()
 		VERIFY(str.find_last_not_of(StringType(LITERAL("abcdfg"))) == 28);
 		VERIFY(str.find_last_not_of(StringType(LITERAL("abcdfgh"))) == 22);
 		VERIFY(str.find_last_not_of(LITERAL("abcdfgh")) == 22);
-		// VERIFY(str.find_last_not_of(LITERAL("abcdfg"), 2, 2) == 0);   // todo:  FIX ME 
-		// VERIFY(str.find_last_not_of(LITERAL("abcdfg"), 0, 2) == 10);  // todo:  FIX ME 
-		VERIFY(str.find_last_not_of(LITERAL('a')) == 28);  
+		// VERIFY(str.find_last_not_of(LITERAL("abcdfg"), 2, 2) == 0);   // todo:  FIX ME
+		// VERIFY(str.find_last_not_of(LITERAL("abcdfg"), 0, 2) == 10);  // todo:  FIX ME
+		VERIFY(str.find_last_not_of(LITERAL('a')) == 28);
 	}
 
 	// this_type substr(size_type position = 0, size_type n = npos) const;
@@ -1840,7 +1864,7 @@ int TEST_STRING_NAME()
 		}
 	}
 
-	
+
 	// this_type left(size_type n) const;
 	// this_type right(size_type n) const;
 	{
@@ -1924,6 +1948,6 @@ int TEST_STRING_NAME()
 }
 
 // Required to prevent manual undef of macros when 'TestString.inl' preprocessed at the top of the unit test cpp file.
-#undef TEST_STRING_NAME 
+#undef TEST_STRING_NAME
 #undef LITERAL
 


### PR DESCRIPTION
There is no constructor overload that accepts the current arguments.
This can be easily fixed by using the basic_string_view + allocator constructor that already carries the string size.