### PR TITLE
C++20: type_trait's endian

### DIFF
--- a/include/EASTL/type_traits.h
+++ b/include/EASTL/type_traits.h
@@ -1071,6 +1071,24 @@ namespace eastl
 	struct static_max<I0, I1, in...>
 		{ static const size_t value = ((I0 >= I1) ? static_max<I0, in...>::value : static_max<I1, in...>::value); };
 
+	///////////////////////////////////////////////////////////////////////
+	/// This enum class is useful for detecting whether a system is little
+	/// or big endian. Mixed or middle endian is not modeled here as described
+	/// by the C++20 spec.
+	///////////////////////////////////////////////////////////////////////
+	enum class endian
+	{
+		#ifdef EA_SYSTEM_LITTLE_ENDIAN
+			little = 1,
+			big = 0,
+			native = little
+		#else
+			little = 0,
+			big = 1,
+			native = big
+		#endif
+	};
+
 } // namespace eastl
 
 

--- a/test/source/TestTypeTraits.cpp
+++ b/test/source/TestTypeTraits.cpp
@@ -1875,6 +1875,21 @@ int TestTypeTraits()
 	#endif
 	}
 
+	// endian (big-endian and little; no mixed-endian/middle-endian)
+	static_assert(eastl::endian::big != eastl::endian::little, "little-endian and big-endian are not the same");
+	static_assert(eastl::endian::native == eastl::endian::big || eastl::endian::native == eastl::endian::little
+		, "native may be little endian or big endian");
+	static_assert(!(eastl::endian::native == eastl::endian::big && eastl::endian::native == eastl::endian::little)
+		, "native cannot be both big and little endian");
+
+	#ifdef EA_SYSTEM_LITTLE_ENDIAN
+		static_assert(eastl::endian::native == eastl::endian::little, "must be little endian");
+		static_assert(eastl::endian::native != eastl::endian::big, "must not be big endian");
+	#else
+		static_assert(eastl::endian::native != eastl::endian::little, "must not be little endian");
+		static_assert(eastl::endian::native == eastl::endian::big, "must be big endian");
+	#endif
+
 	return nErrorCount;
 }
 


### PR DESCRIPTION
Doesn't implement support for mixed-endian (AKA middle-endian): this is in contradiction with how the standard describes how mixed-endian support should behave. I'm assuming that mixed-endian support is not useful for the intended audience of EASTL.