### PR TITLE
Apply usage of compressed_pair to tuple_vector for empty allocators

### DIFF
--- a/include/EASTL/bonus/fixed_tuple_vector.h
+++ b/include/EASTL/bonus/fixed_tuple_vector.h
@@ -65,7 +65,7 @@ public:
 	fixed_tuple_vector(this_type&& x)
 		: base_type(fixed_allocator_type(mBuffer.buffer), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
 	{ 
-		base_type::mAllocator.copy_overflow_allocator(x.mAllocator);
+		base_type::internalAllocator().copy_overflow_allocator(x.internalAllocator());
 		base_type::DoInitFromIterator(make_move_iterator(x.begin()), make_move_iterator(x.end()));
 		x.clear();
 	}
@@ -80,7 +80,7 @@ public:
 	fixed_tuple_vector(const this_type& x)
 		: base_type(fixed_allocator_type(mBuffer.buffer), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
 	{ 
-		base_type::mAllocator.copy_overflow_allocator(x.mAllocator);
+		base_type::internalAllocator().copy_overflow_allocator(x.internalAllocator());
 		base_type::DoInitFromIterator(x.begin(), x.end());
 	}
 
@@ -172,7 +172,7 @@ public:
 	// Returns the value of the bEnableOverflow template parameter.
 	bool can_overflow() const { return bEnableOverflow; }
 
-	const overflow_allocator_type& get_overflow_allocator() const { return base_type::mAllocator.get_overflow_allocator(); }
+	const overflow_allocator_type& get_overflow_allocator() const { return base_type::internalAllocator().get_overflow_allocator(); }
 };
 
 

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -160,7 +160,7 @@ struct TupleRecurser<>
 		// If n is zero, then we allocate no memory and just return NULL. 
 		// This is fine, as our default ctor initializes with NULL pointers. 
 		size_type alignment = TupleRecurser<VecTypes...>::GetTotalAlignment();
-		void* ptr = capacity ? allocate_memory(vec.mAllocator, offset, alignment, 0) : nullptr;
+		void* ptr = capacity ? allocate_memory(vec.internalAllocator(), offset, alignment, 0) : nullptr;
 		return make_pair(ptr, offset);
 	}
 
@@ -226,7 +226,7 @@ struct TupleVecLeaf
 		eastl::destruct(pBegin, pEnd);
 	}
 
-    void DoInsertAndFill(size_type pos, size_type n, size_type numElements, const T& arg)
+	void DoInsertAndFill(size_type pos, size_type n, size_type numElements, const T& arg)
 	{
 		T* pDest = mpData + pos;
 		T* pDataEnd = mpData + numElements;
@@ -246,7 +246,7 @@ struct TupleVecLeaf
 		}
 	}
 
-    void DoInsertRange(T* pSrcBegin, T* pSrcEnd, T* pDestBegin, size_type numDataElements)
+	void DoInsertRange(T* pSrcBegin, T* pSrcEnd, T* pDestBegin, size_type numDataElements)
 	{
 		size_type pos = pDestBegin - mpData;
 		size_type n = pSrcEnd - pSrcBegin;
@@ -266,7 +266,7 @@ struct TupleVecLeaf
 		}
 	}
 
-    void DoInsertValue(size_type pos, size_type numElements, T&& arg)
+	void DoInsertValue(size_type pos, size_type numElements, T&& arg)
 	{
 		T* pDest = mpData + pos;
 		T* pDataEnd = mpData + numElements;
@@ -456,23 +456,23 @@ public:
 	typedef eastl::tuple<Ts&&...> rvalue_tuple;
 
 	TupleVecImpl()
-		: mAllocator(EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: mDataSizeAndAllocator(0, EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
 	{}
 
 	TupleVecImpl(const allocator_type& allocator)
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{}
 
 	TupleVecImpl(this_type&& x)
-		: mAllocator(eastl::move(x.mAllocator))
+		: mDataSizeAndAllocator(0, eastl::move(x.internalAllocator()))
 	{
 		swap(x);
 	}
 
 	TupleVecImpl(this_type&& x, const Allocator& allocator) 
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
-		if (mAllocator == x.mAllocator) // If allocators are equivalent, then we can safely swap member-by-member
+		if (internalAllocator() == x.internalAllocator()) // If allocators are equivalent, then we can safely swap member-by-member
 		{
 			swap(x);
 		}
@@ -484,51 +484,51 @@ public:
 	}
 
 	TupleVecImpl(const this_type& x) 
-		: mAllocator(x.mAllocator)
+		: mDataSizeAndAllocator(0, x.internalAllocator())
 	{
 		DoInitFromIterator(x.begin(), x.end());
 	}
 
 	template<typename OtherAllocator>
 	TupleVecImpl(const TupleVecImpl<OtherAllocator, index_sequence_type, Ts...>& x, const Allocator& allocator)  
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitFromIterator(x.begin(), x.end());
 	}
 
 	template<typename MoveIterBase>
 	TupleVecImpl(move_iterator<MoveIterBase> begin, move_iterator<MoveIterBase> end, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitFromIterator(begin, end);
 	}
 
- 	TupleVecImpl(const_iterator begin, const_iterator end, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
- 		: mAllocator(allocator) 
- 	{
+	TupleVecImpl(const_iterator begin, const_iterator end, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: mDataSizeAndAllocator(0, allocator )
+	{
 		DoInitFromIterator(begin, end);
- 	}
+	}
 
 	TupleVecImpl(size_type n, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitDefaultFill(n);
 	}
 
 	TupleVecImpl(size_type n, const Ts&... args) 
-		: mAllocator(EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: mDataSizeAndAllocator(0, EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
 	{
 		DoInitFillArgs(n, args...);
 	}
 
 	TupleVecImpl(size_type n, const Ts&... args, const allocator_type& allocator) 
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitFillArgs(n, args...);
 	}
 
 	TupleVecImpl(size_type n, const_reference_tuple tup, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
-		: mAllocator(allocator) 
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitFillTuple(n, tup);
 	}
@@ -536,7 +536,7 @@ public:
 protected:
 	// ctor to provide a pre-allocated field of data that the container will own, specifically for fixed_tuple_vector
 	TupleVecImpl(const allocator_type& allocator, void* pData, size_type capacity, size_type dataSize)
-		: mAllocator(allocator), mpData(pData), mNumCapacity(capacity), mDataSize(dataSize)
+		: mpData(pData), mNumCapacity(capacity), mDataSizeAndAllocator(dataSize, allocator)
 	{
 		TupleRecurser<Ts...>::template SetNewData<this_type, 0>(*this, mpData, mNumCapacity, 0);
 	}
@@ -546,14 +546,14 @@ public:
 	{ 
 		swallow((eastl::destruct(TupleVecLeaf<Indices, Ts>::mpData, TupleVecLeaf<Indices, Ts>::mpData + mNumElements), 0)...);
 		if (mpData)
-			EASTLFree(mAllocator, mpData, mDataSize); 
+			EASTLFree(internalAllocator(), mpData, internalDataSize()); 
 	}
 
 	void assign(size_type n, const Ts&... args)
 	{
 		if (n > mNumCapacity)
 		{
-			this_type temp(n, args..., mAllocator); // We have little choice but to reallocate with new memory.
+			this_type temp(n, args..., internalAllocator()); // We have little choice but to reallocate with new memory.
 			swap(temp);
 		}
 		else if (n > mNumElements) // If n > mNumElements ...
@@ -580,7 +580,7 @@ public:
 		size_type newNumElements = last - first;
 		if (newNumElements > mNumCapacity)
 		{
-			this_type temp(first, last, mAllocator);
+			this_type temp(first, last, internalAllocator());
 			swap(temp);
 		}
 		else
@@ -677,10 +677,10 @@ public:
 				swallow(::new ((Ts*)ppNewLeaf[Indices] + firstIdx) Ts(eastl::forward<Ts>(args))...);
 				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 
-				EASTLFree(mAllocator, mpData, mDataSize);
+				EASTLFree(internalAllocator(), mpData, internalDataSize());
 				mpData = allocation.first;
-				mDataSize = allocation.second;
 				mNumCapacity = newCapacity;
+				internalDataSize() = allocation.second;
 			}
 			else
 			{
@@ -723,10 +723,10 @@ public:
 				swallow((eastl::uninitialized_fill_ptr((Ts*)ppNewLeaf[Indices] + firstIdx, (Ts*)ppNewLeaf[Indices] + lastIdx, args), 0)...);
 				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 		
-				EASTLFree(mAllocator, mpData, mDataSize);
+				EASTLFree(internalAllocator(), mpData, internalDataSize());
 				mpData = allocation.first;
-				mDataSize = allocation.second;
 				mNumCapacity = newCapacity;
+				internalDataSize() = allocation.second;
 			}
 			else
 			{
@@ -762,13 +762,13 @@ public:
 		{
 			if (newNumElements > oldNumCapacity)
 			{
- 				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
- 
- 				void* ppNewLeaf[sizeof...(Ts)];
+				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
+
+				void* ppNewLeaf[sizeof...(Ts)];
 				pair<void*, size_type> allocation = TupleRecurser<Ts...>::template DoAllocate<allocator_type, 0, index_sequence_type, Ts...>(
- 						*this, ppNewLeaf, newCapacity, 0);
- 
- 				swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(
+						*this, ppNewLeaf, newCapacity, 0);
+
+				swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(
 					0, posIdx, (Ts*)ppNewLeaf[Indices]), 0)...);
 				swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(
 					posIdx, oldNumElements, (Ts*)ppNewLeaf[Indices] + posIdx + numToInsert), 0)...);
@@ -777,10 +777,10 @@ public:
 						                       (Ts*)ppNewLeaf[Indices] + posIdx), 0)...);
 				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 				
-				EASTLFree(mAllocator, mpData, mDataSize);
- 				mpData = allocation.first;
- 				mDataSize = allocation.second;
- 				mNumCapacity = newCapacity;
+				EASTLFree(internalAllocator(), mpData, internalDataSize());
+				mpData = allocation.first;
+				mNumCapacity = newCapacity;
+				internalDataSize() = allocation.second;
 			}
 			else
 			{
@@ -849,7 +849,7 @@ public:
 			if (n > oldNumCapacity)
 			{
 				DoReallocate(oldNumElements, eastl::max<size_type>(GetNewCapacity(oldNumCapacity), n));
-			} 
+			}
 			swallow((eastl::uninitialized_default_fill_n(TupleVecLeaf<Indices, Ts>::mpData + oldNumElements, n - oldNumElements), 0)...);
 		}
 		else
@@ -887,7 +887,7 @@ public:
 
 	void shrink_to_fit()
 	{
-		this_type temp(move_iterator<iterator>(begin()), move_iterator<iterator>(end()), mAllocator);
+		this_type temp(move_iterator<iterator>(begin()), move_iterator<iterator>(end()), internalAllocator());
 		swap(temp);
 	}
 
@@ -912,11 +912,11 @@ public:
 	void swap(this_type& x)
 	{
 		swallow((eastl::swap(TupleVecLeaf<Indices, Ts>::mpData, x.TupleVecLeaf<Indices, Ts>::mpData), 0)...);
-		eastl::swap(mAllocator, x.mAllocator);
 		eastl::swap(mpData, x.mpData);
-		eastl::swap(mDataSize, x.mDataSize);
 		eastl::swap(mNumElements, x.mNumElements);
 		eastl::swap(mNumCapacity, x.mNumCapacity);
+		eastl::swap(internalAllocator(), x.internalAllocator());
+		eastl::swap(internalDataSize(), x.internalDataSize());
 	}
 
 	void assign(size_type n, const_reference_tuple tup) { assign(n, eastl::get<Indices>(tup)...); }
@@ -1086,7 +1086,7 @@ public:
 			return false;
 		if (!(variadicAnd(mpData <= TupleVecLeaf<Indices, Ts>::mpData...)))
 			return false;
-		void* pDataEnd = (void*)((uintptr_t)mpData + mDataSize);
+		void* pDataEnd = (void*)((uintptr_t)mpData + internalDataSize());
 		if (!(variadicAnd(pDataEnd >= TupleVecLeaf<Indices, Ts>::mpData...)))
 			return false;
 		return true;
@@ -1115,12 +1115,17 @@ public:
 	static bool validate_iterator_pair(Iterator first, Iterator last) EA_NOEXCEPT { return validate_iterator_pair(unwrap_iterator(first), unwrap_iterator(last)); }
 
 protected:
-	allocator_type mAllocator;
 
 	void* mpData = nullptr;
-	size_type mDataSize = 0;
 	size_type mNumElements = 0;
 	size_type mNumCapacity = 0;
+
+	compressed_pair<size_type, allocator_type> mDataSizeAndAllocator;
+
+	size_type& internalDataSize() EA_NOEXCEPT { return mDataSizeAndAllocator.first(); }
+	size_type const& internalDataSize() const EA_NOEXCEPT { return mDataSizeAndAllocator.first(); }
+	allocator_type& internalAllocator() EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
+	const allocator_type& internalAllocator() const EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
 
 	friend struct TupleRecurser<>;
 	template<typename... Us>
@@ -1199,10 +1204,10 @@ protected:
 		swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(0, oldNumElements, (Ts*)ppNewLeaf[Indices]), 0)...);
 		swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 
-		EASTLFree(mAllocator, mpData, mDataSize);
+		EASTLFree(internalAllocator(), mpData, internalDataSize());
 		mpData = allocation.first;
-		mDataSize = allocation.second;
 		mNumCapacity = requiredCapacity;
+		internalDataSize() = allocation.second;
 	}
 
 	size_type GetNewCapacity(size_type oldNumCapacity)


### PR DESCRIPTION
As suggested here: https://github.com/electronicarts/EASTL/pull/197#discussion_r209438768  This puts the mDataSize member of tuple_vector (used to track how large t_v's allocation itself is) and the mAllocator together into a compressed_pair