### PR TITLE
Adding initializer_list support to tuple_vector (and support for _conditionally_ explicit support for tuple copy/move ctor)

### DIFF
--- a/include/EASTL/bonus/fixed_tuple_vector.h
+++ b/include/EASTL/bonus/fixed_tuple_vector.h
@@ -134,7 +134,7 @@ public:
 		const overflow_allocator_type& allocator = EASTL_FIXED_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
 		: base_type(fixed_allocator_type(mBuffer.buffer, allocator), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
 	{
-		base_type::DoInitFromTupleArray(iList.begin(), iList.end());
+		base_type::DoInitFromTupleArray(first, last);
 	}
 
 	fixed_tuple_vector(std::initializer_list<typename base_type::value_tuple> iList,

--- a/include/EASTL/bonus/fixed_tuple_vector.h
+++ b/include/EASTL/bonus/fixed_tuple_vector.h
@@ -130,6 +130,20 @@ public:
 		base_type::DoInitFillTuple(n, tup);
 	}
 
+	fixed_tuple_vector(const typename base_type::value_tuple* first, const typename base_type::value_tuple* last,
+		const overflow_allocator_type& allocator = EASTL_FIXED_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: base_type(fixed_allocator_type(mBuffer.buffer, allocator), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
+	{
+		base_type::DoInitFromTupleArray(iList.begin(), iList.end());
+	}
+
+	fixed_tuple_vector(std::initializer_list<typename base_type::value_tuple> iList,
+		const overflow_allocator_type& allocator = EASTL_FIXED_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: base_type(fixed_allocator_type(mBuffer.buffer, allocator), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
+	{
+		base_type::DoInitFromTupleArray(iList.begin(), iList.end());
+	}
+
 	this_type& operator=(const this_type& other)
 	{
 		(base_type&)(*this) = (base_type&)other;

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -262,7 +262,7 @@ struct TupleVecLeaf
 		{
 			eastl::uninitialized_copy(pSrcEnd - (n - nExtra), pSrcEnd, pDataEnd);
 			eastl::uninitialized_move_ptr(pDestBegin, pDataEnd, pDataEnd + n - nExtra);
-			eastl::copy(pSrcBegin, pSrcEnd, pDestBegin);
+			eastl::copy(pSrcBegin, pSrcEnd - (n - nExtra), pDestBegin);
 		}
 	}
 

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -901,8 +901,8 @@ public:
 					swallow((eastl::uninitialized_move_ptr((Ts*)ppDataBegin[Indices],
 						(Ts*)ppDataEnd[Indices], (Ts*)ppDataEnd[Indices] + numToInitialize), 0)...);
 					
-					DoCopyFromTupleArray(pos, pos + numToInitialize, first);
-					DoUninitializedCopyFromTupleArray(pos + numToInitialize, pos + numToInsert, first + numToInitialize);
+					DoCopyFromTupleArray(pos, begin() + oldNumElements, first);
+					DoUninitializedCopyFromTupleArray(begin() + oldNumElements, pos + numToInsert, first + nExtra);
 				}
 			}
 		}

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -1296,20 +1296,19 @@ protected:
 
 	void DoInitFromTupleArray(const value_tuple* first, const value_tuple* last)
 	{
-		// dcrooks-todo
-//#if EASTL_ASSERT_ENABLED
-//		if (EASTL_UNLIKELY(!validate_iterator_pair(begin, end)))
-//			EASTL_FAIL_MSG("tuple_vector::erase -- invalid iterator pair");
-//#endif
-//		size_type newNumElements = (size_type)(end - begin);
-//		const void* ppOtherData[sizeof...(Ts)] = { begin.mpData[Indices]... };
-//		size_type beginIdx = begin.mIndex;
-//		size_type endIdx = end.mIndex;
-//		DoConditionalReallocate(0, mNumCapacity, newNumElements);
-//		mNumElements = newNumElements;
-//		swallow((eastl::uninitialized_copy_ptr((Ts*)(ppOtherData[Indices]) + beginIdx,
-//			(Ts*)(ppOtherData[Indices]) + endIdx,
-//			TupleVecLeaf<Indices, Ts>::mpData), 0)...);
+#if EASTL_ASSERT_ENABLED
+		if (EASTL_UNLIKELY(first > last || first == nullptr || last == nullptr))
+			EASTL_FAIL_MSG("tuple_vector::ctor from tuple array -- invalid ptrs");
+#endif
+		size_type newNumElements = (size_type)(last - first);
+		DoConditionalReallocate(0, mNumCapacity, newNumElements);
+		mNumElements = newNumElements;
+		
+		iterator writeIter = begin();
+		for (size_type idx = 0; idx < newNumElements; ++idx, ++first)
+		{
+			swallow(::new(TupleVecLeaf<Indices, Ts>::mpData + idx) Ts(eastl::get<Indices>(*first))...);
+		}
 	}
 
 

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -533,6 +533,18 @@ public:
 		DoInitFillTuple(n, tup);
 	}
 
+	TupleVecImpl(const value_tuple* first, const value_tuple* last, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: mAllocator(allocator)
+	{
+		DoInitFromTupleArray(first, last);
+	}
+
+	TupleVecImpl(std::initializer_list<value_tuple> iList, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
+		: mAllocator(allocator)
+	{
+		DoInitFromTupleArray(iList.begin(), iList.end());
+	}
+
 protected:
 	// ctor to provide a pre-allocated field of data that the container will own, specifically for fixed_tuple_vector
 	TupleVecImpl(const allocator_type& allocator, void* pData, size_type capacity, size_type dataSize)
@@ -606,6 +618,43 @@ public:
 				erase(begin() + newNumElements, end());
 			}
 		}
+	}
+
+	void assign(const value_tuple* first, const value_tuple* last)
+	{
+//#if EASTL_ASSERT_ENABLED
+//		if (EASTL_UNLIKELY(!validate_iterator_pair(first, last)))
+//			EASTL_FAIL_MSG("tuple_vector::assign -- invalid iterator pair");
+//#endif
+//		size_type newNumElements = last - first;
+//		if (newNumElements > mNumCapacity)
+//		{
+//			this_type temp(first, last, mAllocator);
+//			swap(temp);
+//		}
+//		else
+//		{
+//			const void* ppOtherData[sizeof...(Ts)] = { first.mpData[Indices]... };
+//			size_type firstIdx = first.mIndex;
+//			size_type lastIdx = last.mIndex;
+//			if (newNumElements > mNumElements) // If n > mNumElements ...
+//			{
+//				size_type oldNumElements = mNumElements;
+//				swallow((eastl::copy((Ts*)(ppOtherData[Indices]) + firstIdx,
+//					(Ts*)(ppOtherData[Indices]) + firstIdx + oldNumElements,
+//					TupleVecLeaf<Indices, Ts>::mpData), 0)...);
+//				swallow((eastl::uninitialized_copy_ptr((Ts*)(ppOtherData[Indices]) + firstIdx + oldNumElements,
+//					(Ts*)(ppOtherData[Indices]) + lastIdx,
+//					TupleVecLeaf<Indices, Ts>::mpData + oldNumElements), 0)...);
+//				mNumElements = newNumElements;
+//			}
+//			else // else 0 <= n <= mNumElements
+//			{
+//				swallow((eastl::copy((Ts*)(ppOtherData[Indices]) + firstIdx, (Ts*)(ppOtherData[Indices]) + lastIdx,
+//					TupleVecLeaf<Indices, Ts>::mpData), 0)...);
+//				erase(begin() + newNumElements, end());
+//			}
+//		}
 	}
 
 	reference_tuple push_back()
@@ -798,6 +847,61 @@ public:
 		return begin() + posIdx;
 	}
 
+	iterator insert(const_iterator pos, const value_tuple* first, const value_tuple* last)
+	{
+//#if EASTL_ASSERT_ENABLED
+//		if (EASTL_UNLIKELY(validate_iterator(pos) == isf_none))
+//			EASTL_FAIL_MSG("tuple_vector::insert -- invalid iterator");
+//		if (EASTL_UNLIKELY(last < first || first == nullptr || last == nullptr))
+//			EASTL_FAIL_MSG("tuple_vector::insert -- invalid source pointers");
+//#endif
+		size_type posIdx = pos - cbegin();
+//		size_type numToInsert = end - begin;
+//		size_type oldNumElements = mNumElements;
+//		size_type newNumElements = oldNumElements + numToInsert;
+//		size_type oldNumCapacity = mNumCapacity;
+//		mNumElements = newNumElements;
+//		const value_tuple* pInitListData = iList.begin();
+//		if (newNumElements > oldNumCapacity || posIdx != oldNumElements)
+//		{
+//			if (newNumElements > oldNumCapacity)
+//			{
+//				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
+//
+//				void* ppNewLeaf[sizeof...(Ts)];
+//				pair<void*, size_type> allocation = TupleRecurser<Ts...>::template DoAllocate<allocator_type, 0, index_sequence_type, Ts...>(
+//					*this, ppNewLeaf, newCapacity, 0);
+//
+//				swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(
+//					0, posIdx, (Ts*)ppNewLeaf[Indices]), 0)...);
+//				swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(
+//					posIdx, oldNumElements, (Ts*)ppNewLeaf[Indices] + posIdx + numToInsert), 0)...);
+//				//swallow((eastl::uninitialized_copy_ptr((Ts*)(ppOtherData[Indices]) + firstIdx,
+//				//	(Ts*)(ppOtherData[Indices]) + lastIdx,
+//				//	(Ts*)ppNewLeaf[Indices] + posIdx), 0)...);
+//				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
+//
+//				EASTLFree(mAllocator, mpData, mDataSize);
+//				mpData = allocation.first;
+//				mDataSize = allocation.second;
+//				mNumCapacity = newCapacity;
+//			}
+//			else
+//			{
+//				//swallow((TupleVecLeaf<Indices, Ts>::DoInsertRange(
+//				//	(Ts*)(ppOtherData[Indices]) + firstIdx, (Ts*)(ppOtherData[Indices]) + lastIdx,
+//				//	TupleVecLeaf<Indices, Ts>::mpData + posIdx, oldNumElements), 0)...);
+//			}
+//		}
+//		else
+//		{
+//			//swallow((eastl::uninitialized_copy_ptr((Ts*)(ppOtherData[Indices]) + firstIdx,
+//			//	(Ts*)(ppOtherData[Indices]) + lastIdx,
+//			//	TupleVecLeaf<Indices, Ts>::mpData + posIdx), 0)...);
+//		}
+		return begin() + posIdx;
+	}
+
 	iterator erase(const_iterator first, const_iterator last)
 	{
 #if EASTL_ASSERT_ENABLED
@@ -920,6 +1024,7 @@ public:
 	}
 
 	void assign(size_type n, const_reference_tuple tup) { assign(n, eastl::get<Indices>(tup)...); }
+	void assign(std::initializer_list<value_tuple> iList) { assign(iList.begin(), iList.end()); }
 
 	void push_back(Ts&&... args) { emplace_back(eastl::forward<Ts>(args)...); }
 	void push_back(const_reference_tuple tup) { push_back(eastl::get<Indices>(tup)...); }
@@ -933,6 +1038,7 @@ public:
 	iterator insert(const_iterator pos, rvalue_tuple tup) { return emplace(pos, eastl::forward<Ts>(eastl::get<Indices>(tup))...); }
 	iterator insert(const_iterator pos, const_reference_tuple tup) { return insert(pos, eastl::get<Indices>(tup)...); }
 	iterator insert(const_iterator pos, size_type n, const_reference_tuple tup) { return insert(pos, n, eastl::get<Indices>(tup)...); }
+	iterator insert(const_iterator pos, std::initializer_list<value_tuple> iList) { return insert(pos, iList.begin(), iList.end()); }
 
 	iterator erase(const_iterator pos) { return erase(pos, pos + 1); }
 	reverse_iterator erase(const_reverse_iterator pos) { return reverse_iterator(erase((pos + 1).base(), (pos).base())); }
@@ -1080,6 +1186,12 @@ public:
 		return *this;
 	}
 
+	this_type& operator=(std::initializer_list<value_tuple> iList) 
+	{
+		assign(iList.begin, iList.end());
+		return *this; 
+	}
+
 	bool validate() const EA_NOEXCEPT
 	{
 		if (mNumElements > mNumCapacity)
@@ -1181,6 +1293,25 @@ protected:
 		mNumElements = n;
 		swallow((eastl::uninitialized_default_fill_n(TupleVecLeaf<Indices, Ts>::mpData, n), 0)...);
 	}
+
+	void DoInitFromTupleArray(const value_tuple* first, const value_tuple* last)
+	{
+		// dcrooks-todo
+//#if EASTL_ASSERT_ENABLED
+//		if (EASTL_UNLIKELY(!validate_iterator_pair(begin, end)))
+//			EASTL_FAIL_MSG("tuple_vector::erase -- invalid iterator pair");
+//#endif
+//		size_type newNumElements = (size_type)(end - begin);
+//		const void* ppOtherData[sizeof...(Ts)] = { begin.mpData[Indices]... };
+//		size_type beginIdx = begin.mIndex;
+//		size_type endIdx = end.mIndex;
+//		DoConditionalReallocate(0, mNumCapacity, newNumElements);
+//		mNumElements = newNumElements;
+//		swallow((eastl::uninitialized_copy_ptr((Ts*)(ppOtherData[Indices]) + beginIdx,
+//			(Ts*)(ppOtherData[Indices]) + endIdx,
+//			TupleVecLeaf<Indices, Ts>::mpData), 0)...);
+	}
+
 
 	// Try to grow the size of the container "naturally" given the number of elements being used
 	void DoGrow(size_type oldNumElements, size_type oldNumCapacity, size_type requiredCapacity)

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -534,13 +534,13 @@ public:
 	}
 
 	TupleVecImpl(const value_tuple* first, const value_tuple* last, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitFromTupleArray(first, last);
 	}
 
 	TupleVecImpl(std::initializer_list<value_tuple> iList, const allocator_type& allocator = EASTL_TUPLE_VECTOR_DEFAULT_ALLOCATOR)
-		: mAllocator(allocator)
+		: mDataSizeAndAllocator(0, allocator)
 	{
 		DoInitFromTupleArray(iList.begin(), iList.end());
 	}
@@ -629,7 +629,7 @@ public:
 		size_type newNumElements = last - first;
 		if (newNumElements > mNumCapacity)
 		{
-			this_type temp(first, last, mAllocator);
+			this_type temp(first, last, internalAllocator());
 			swap(temp);
 		}
 		else
@@ -875,10 +875,10 @@ public:
 				// Do this after mpData is updated so that we can use new iterators
 				DoUninitializedCopyFromTupleArray(begin() + posIdx, begin() + posIdx + numToInsert, first);
 
-				EASTLFree(mAllocator, mpData, mDataSize);
+				EASTLFree(internalAllocator(), mpData, internalDataSize());
 				mpData = allocation.first;
-				mDataSize = allocation.second;
 				mNumCapacity = newCapacity;
+				internalDataSize() = allocation.second;
 			}
 			else
 			{

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -691,24 +691,52 @@ class tuple
 public:
 	EA_CONSTEXPR tuple() = default;
 
+
+	template <
+		typename = typename enable_if<
+		Internal::TupleConvertible<tuple<const Ts&...>, tuple>::value,
+		bool>::type>
+	EA_CONSTEXPR tuple(const Ts&... t)
+		: mImpl(make_index_sequence<sizeof...(Ts)>{}, Internal::MakeTupleTypes_t<tuple>{}, t...)
+	{
+	}
+
+	template <typename _ = void, // need an extra type so that compiler can better differentiate from non-explicit variant of ctor
+		typename = typename enable_if<
+		!Internal::TupleConvertible<tuple<const Ts&...>, tuple>::value,
+		bool>::type>
 	explicit EA_CONSTEXPR tuple(const Ts&... t)
 		: mImpl(make_index_sequence<sizeof...(Ts)>{}, Internal::MakeTupleTypes_t<tuple>{}, t...)
 	{
 	}
 
 	template <typename U, typename... Us,
-			  typename = typename enable_if<
-				  sizeof...(Us) + 1 == sizeof...(Ts) && Internal::TupleConvertible<tuple<U, Us...>, tuple>::value,
-				  bool>::type>
-	explicit EA_CONSTEXPR tuple(U&& u, Us&&... us)
+		typename = typename enable_if<
+		sizeof...(Us) + 1 == sizeof...(Ts) && 
+		Internal::TupleConvertible<tuple<U, Us...>, tuple>::value,
+		bool>::type>
+	EA_CONSTEXPR tuple(U&& u, Us&&... us)
 		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, forward<U>(u),
-				forward<Us>(us)...)
+			forward<Us>(us)...)
 	{
 	}
 
+	template <typename _ = void, // need an extra type so that compiler can better differentiate from non-explicit variant of ctor
+		typename U, typename... Us,
+		typename = typename enable_if<
+		sizeof...(Us) + 1 == sizeof...(Ts) &&
+		!Internal::TupleConvertible<tuple<U, Us...>, tuple>::value,
+		bool>::type>
+	explicit EA_CONSTEXPR tuple(U&& u, Us&&... us)
+		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, forward<U>(u),
+			forward<Us>(us)...)
+	{
+	}
+
+
 	template <typename OtherTuple,
-			  typename enable_if<Internal::TupleConvertible<OtherTuple, tuple>::value, bool>::type = false>
-	tuple(OtherTuple&& t)
+		typename enable_if<Internal::TupleConvertible<OtherTuple, tuple>::value, bool>::type = false>
+		tuple(OtherTuple&& t)
 		: mImpl(forward<OtherTuple>(t))
 	{
 	}

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -480,23 +480,13 @@ struct TupleConvertibleImpl : public false_type
 {
 };
 
-template <typename FromFirst, typename... FromRest, typename ToFirst, typename... ToRest>
-struct TupleConvertibleImpl<
-	true, TupleTypes<FromFirst, FromRest...>,
-	TupleTypes<ToFirst, ToRest...>> : public integral_constant<bool,
-															   is_convertible<FromFirst, ToFirst>::value&&
-																   TupleConvertibleImpl<true, TupleTypes<FromRest...>,
-																						TupleTypes<ToRest...>>::value>
+template <typename... FromTypes, typename... ToTypes>
+struct TupleConvertibleImpl<true, TupleTypes<FromTypes...>,	TupleTypes<ToTypes...>>
+	: public integral_constant<bool, conjunction<is_convertible<FromTypes, ToTypes>...>::value>
 {
 };
 
-template <>
-struct TupleConvertibleImpl<true, TupleTypes<>, TupleTypes<>> : public true_type
-{
-};
-
-template <typename From,
-		  typename To,
+template <typename From, typename To,
 		  bool = TupleLike<typename remove_reference<From>::type>::value,
 		  bool = TupleLike<typename remove_reference<To>::type>::value>
 struct TupleConvertible : public false_type
@@ -506,9 +496,8 @@ struct TupleConvertible : public false_type
 template <typename From, typename To>
 struct TupleConvertible<From, To, true, true>
 	: public TupleConvertibleImpl<tuple_size<typename remove_reference<From>::type>::value ==
-		                              tuple_size<typename remove_reference<To>::type>::value,
-		                          MakeTupleTypes_t<From>,
-		                          MakeTupleTypes_t<To>>
+			tuple_size<typename remove_reference<To>::type>::value,
+			MakeTupleTypes_t<From>, MakeTupleTypes_t<To>>
 {
 };
 
@@ -519,20 +508,13 @@ struct TupleAssignableImpl : public false_type
 {
 };
 
-template <typename TargetFirst, typename... TargetRest, typename FromFirst, typename... FromRest>
-struct TupleAssignableImpl<true, TupleTypes<TargetFirst, TargetRest...>, TupleTypes<FromFirst, FromRest...>>
-	: public bool_constant<is_assignable<TargetFirst, FromFirst>::value &&
-		                   TupleAssignableImpl<true, TupleTypes<TargetRest...>, TupleTypes<FromRest...>>::value>
+template <typename... TargetTypes, typename... FromTypes>
+struct TupleAssignableImpl<true, TupleTypes<TargetTypes...>, TupleTypes<FromTypes...>>
+	: public bool_constant<conjunction<is_assignable<TargetTypes, FromTypes>...>::value>
 {
 };
 
-template <>
-struct TupleAssignableImpl<true, TupleTypes<>, TupleTypes<>> : public true_type
-{
-};
-
-template <typename Target,
-		  typename From,
+template <typename Target, typename From,
 		  bool = TupleLike<typename remove_reference<Target>::type>::value,
 		  bool = TupleLike<typename remove_reference<From>::type>::value>
 struct TupleAssignable : public false_type
@@ -541,11 +523,63 @@ struct TupleAssignable : public false_type
 
 template <typename Target, typename From>
 struct TupleAssignable<Target, From, true, true>
-	: public TupleAssignableImpl<tuple_size<typename remove_reference<Target>::type>::value == tuple_size<typename remove_reference<From>::type>::value,
-		                         MakeTupleTypes_t<Target>,
-		                         MakeTupleTypes_t<From>>
+	: public TupleAssignableImpl<
+		tuple_size<typename remove_reference<Target>::type>::value ==
+		tuple_size<typename remove_reference<From>::type>::value,
+		MakeTupleTypes_t<Target>, MakeTupleTypes_t<From>>
 {
 };
+
+// TupleImplicitlyConvertible and TupleExplicitlyConvertible - helpers for constraining conditionally-explicit ctors
+
+template <bool IsSameSize, typename TargetType, typename... FromTypes>
+struct TupleImplicitlyConvertibleImpl : public false_type
+{
+};
+
+
+template <typename... TargetTypes, typename... FromTypes>
+struct TupleImplicitlyConvertibleImpl<true, TupleTypes<TargetTypes...>, FromTypes...>
+	: public conjunction<
+	is_constructible<TargetTypes, FromTypes>...,
+	is_convertible<FromTypes, TargetTypes>...>
+{
+};
+
+template <typename TargetTupleType, typename... FromTypes>
+struct TupleImplicitlyConvertible
+	: public TupleImplicitlyConvertibleImpl<
+	tuple_size<TargetTupleType>::value == sizeof...(FromTypes),
+	MakeTupleTypes_t<TargetTupleType>, FromTypes...>::type
+{
+};
+
+template<typename TargetTupleType, typename... FromTypes>
+using TupleImplicitlyConvertible_t = enable_if_t<TupleImplicitlyConvertible<TargetTupleType, FromTypes...>::value, bool>;
+
+template <bool IsSameSize, typename TargetType, typename... FromTypes>
+struct TupleExplicitlyConvertibleImpl : public false_type
+{
+};
+
+template <typename... TargetTypes, typename... FromTypes>
+struct TupleExplicitlyConvertibleImpl<true, TupleTypes<TargetTypes...>, FromTypes...>
+	: public conjunction<
+		is_constructible<TargetTypes, FromTypes>...,
+		negation<conjunction<is_convertible<FromTypes, TargetTypes>...>>>
+{
+};
+
+template <typename TargetTupleType, typename... FromTypes>
+struct TupleExplicitlyConvertible
+	: public TupleExplicitlyConvertibleImpl<
+	tuple_size<TargetTupleType>::value == sizeof...(FromTypes),
+	MakeTupleTypes_t<TargetTupleType>, FromTypes...>::type
+{
+};
+
+template<typename TargetTupleType, typename... FromTypes>
+using TupleExplicitlyConvertible_t = enable_if_t<TupleExplicitlyConvertible<TargetTupleType, FromTypes...>::value, bool>;
 
 // TupleEqual
 
@@ -686,57 +720,47 @@ struct TupleCat<Tuple1, Tuple2>
 }  // namespace Internal
 
 template <typename... Ts>
-class tuple
+class tuple;
+
+template <typename T, typename... Ts>
+class tuple<T, Ts...>
 {
 public:
 	EA_CONSTEXPR tuple() = default;
-
-
-	template <
-		typename = typename enable_if<
-		Internal::TupleConvertible<tuple<const Ts&...>, tuple>::value,
-		bool>::type>
-	EA_CONSTEXPR tuple(const Ts&... t)
-		: mImpl(make_index_sequence<sizeof...(Ts)>{}, Internal::MakeTupleTypes_t<tuple>{}, t...)
+	
+	template <typename T2 = T, 
+		Internal::TupleImplicitlyConvertible_t<tuple, const T2&, const Ts&...> = 0>
+	EA_CONSTEXPR tuple(const T& t, const Ts&... ts)
+		: mImpl(make_index_sequence<sizeof...(Ts) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, t, ts...)
 	{
 	}
 
-	template <typename _ = void, // need an extra type so that compiler can better differentiate from non-explicit variant of ctor
-		typename = typename enable_if<
-		!Internal::TupleConvertible<tuple<const Ts&...>, tuple>::value,
-		bool>::type>
-	explicit EA_CONSTEXPR tuple(const Ts&... t)
-		: mImpl(make_index_sequence<sizeof...(Ts)>{}, Internal::MakeTupleTypes_t<tuple>{}, t...)
+	template <typename T2 = T, 
+		Internal::TupleExplicitlyConvertible_t<tuple, const T2&, const Ts&...> = 0>
+	explicit EA_CONSTEXPR tuple(const T& t, const Ts&... ts)
+		: mImpl(make_index_sequence<sizeof...(Ts) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, t, ts...)
 	{
 	}
 
 	template <typename U, typename... Us,
-		typename = typename enable_if<
-		sizeof...(Us) + 1 == sizeof...(Ts) && 
-		Internal::TupleConvertible<tuple<U, Us...>, tuple>::value,
-		bool>::type>
-	EA_CONSTEXPR tuple(U&& u, Us&&... us)
+		Internal::TupleImplicitlyConvertible_t<tuple, U, Us...> = 0>
+		EA_CONSTEXPR tuple(U&& u, Us&&... us)
 		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, forward<U>(u),
 			forward<Us>(us)...)
 	{
 	}
 
-	template <typename _ = void, // need an extra type so that compiler can better differentiate from non-explicit variant of ctor
-		typename U, typename... Us,
-		typename = typename enable_if<
-		sizeof...(Us) + 1 == sizeof...(Ts) &&
-		!Internal::TupleConvertible<tuple<U, Us...>, tuple>::value,
-		bool>::type>
-	explicit EA_CONSTEXPR tuple(U&& u, Us&&... us)
+	template <typename U, typename... Us,
+		Internal::TupleExplicitlyConvertible_t<tuple, U, Us...> = 0>
+		explicit EA_CONSTEXPR tuple(U&& u, Us&&... us)
 		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, forward<U>(u),
 			forward<Us>(us)...)
 	{
 	}
-
 
 	template <typename OtherTuple,
-		typename enable_if<Internal::TupleConvertible<OtherTuple, tuple>::value, bool>::type = false>
-		tuple(OtherTuple&& t)
+			  typename enable_if<Internal::TupleConvertible<OtherTuple, tuple>::value, bool>::type = false>
+	tuple(OtherTuple&& t)
 		: mImpl(forward<OtherTuple>(t))
 	{
 	}
@@ -752,7 +776,7 @@ public:
 	void swap(tuple& t) { mImpl.swap(t.mImpl); }
 
 private:
-	typedef Internal::TupleImpl<make_index_sequence<sizeof...(Ts)>, Ts...> Impl;
+	typedef Internal::TupleImpl<make_index_sequence<sizeof...(Ts) + 1>, T, Ts...> Impl;
 	Impl mImpl;
 
 	template <size_t I, typename... Ts_>
@@ -764,14 +788,14 @@ private:
 	template <size_t I, typename... Ts_>
 	friend tuple_element_t<I, tuple<Ts_...>>&& get(tuple<Ts_...>&& t);
 
-	template <typename T, typename... ts_>
-	friend T& get(tuple<ts_...>& t);
+	template <typename T_, typename... ts_>
+	friend T_& get(tuple<ts_...>& t);
 
-	template <typename T, typename... ts_>
-	friend const T& get(const tuple<ts_...>& t);
+	template <typename T_, typename... ts_>
+	friend const T_& get(const tuple<ts_...>& t);
 
-	template <typename T, typename... ts_>
-	friend T&& get(tuple<ts_...>&& t);
+	template <typename T_, typename... ts_>
+	friend T_&& get(tuple<ts_...>&& t);
 };
 
 template <>

--- a/test/source/TestFixedTupleVector.cpp
+++ b/test/source/TestFixedTupleVector.cpp
@@ -499,27 +499,27 @@ int TestFixedTupleVectorVariant()
 			// test insert on empty vector that doesn't cause growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(3), 3.0f);
 			testVec.insert(testVec.begin(), {
-				tuple<bool, TestObject, float>{true, TestObject(3), 3.0f},
+				{true, TestObject(3), 3.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(3), 3.0f}
+				{true, TestObject(3), 3.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 3);
 
 			// test insert to end of vector that doesn't cause growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(5), 5.0f);
 			testVec.insert(testVec.end(), {
-				tuple<bool, TestObject, float>{true, TestObject(5), 5.0f},
+				{true, TestObject(5), 5.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(5), 5.0f}
+				{true, TestObject(5), 5.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 6);
 
 			// test insert to middle of vector that doesn't cause growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(4), 4.0f);
 			testVec.insert(testVec.begin() + 3, {
-				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f},
+				{true, TestObject(4), 4.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f}
+				{true, TestObject(4), 4.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 9);
 			EATEST_VERIFY(testVec.capacity() == 10 || testVec.capacity() == nodeCount);
@@ -527,9 +527,9 @@ int TestFixedTupleVectorVariant()
 			// test insert to end of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(6), 6.0f);
 			testVec.insert(testVec.end(), {
-				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f},
+				{true, TestObject(6), 6.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f}
+				{true, TestObject(6), 6.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 12);
 			if (testVec.has_overflowed())
@@ -541,9 +541,9 @@ int TestFixedTupleVectorVariant()
 			// test insert to beginning of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(1), 1.0f);
 			testVec.insert(testVec.begin(), {
-				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f},
+				{true, TestObject(1), 1.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f}
+				{true, TestObject(1), 1.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 15);
 			if (testVec.has_overflowed())
@@ -555,9 +555,9 @@ int TestFixedTupleVectorVariant()
 			// test insert to middle of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(2), 2.0f);
 			testVec.insert(testVec.begin() + 3, {
-				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f},
+				{true, TestObject(2), 2.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f
+				{true, TestObject(2), 2.0f
 			} });
 			EATEST_VERIFY(testVec.size() == 18);
 			if (testVec.has_overflowed())
@@ -847,9 +847,9 @@ int TestFixedTupleVectorVariant()
 
 			// test assign from initList that grows the capacity
 			testVec.assign({
-				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f },
-				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f },
-				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f }
+				{ true, TestObject(1), 1.0f },
+				{ true, TestObject(1), 1.0f },
+				{ true, TestObject(1), 1.0f }
 				});
 			EATEST_VERIFY(testVec.size() == 3);
 			for (unsigned int i = 0; i < testVec.size(); ++i)
@@ -860,7 +860,7 @@ int TestFixedTupleVectorVariant()
 
 			// test assign from initList that shrinks the vector
 			testVec.assign({
-				tuple<bool, TestObject, float>{ true, TestObject(2), 2.0f }
+				{ true, TestObject(2), 2.0f }
 				});
 			EATEST_VERIFY(testVec.size() == 1);
 			for (unsigned int i = 0; i < testVec.size(); ++i)
@@ -871,8 +871,8 @@ int TestFixedTupleVectorVariant()
 
 			// test assign from initList for when there's enough capacity
 			testVec.assign({
-				tuple<bool, TestObject, float>{ true, TestObject(3), 3.0f },
-				tuple<bool, TestObject, float>{ true, TestObject(3), 3.0f }
+				{ true, TestObject(3), 3.0f },
+				{ true, TestObject(3), 3.0f }
 				});
 			EATEST_VERIFY(testVec.size() == 2);
 			for (unsigned int i = 0; i < testVec.size(); ++i)
@@ -1011,16 +1011,16 @@ int TestFixedTupleVectorVariant()
 		//			srcVec.push_back(i % 3 == 0, TestObject(i), (float)i);
 
 		fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> srcVec({
-			tuple<bool, TestObject, float>{ true,  TestObject(0), 0.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(1), 1.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(2), 2.0f},
-			tuple<bool, TestObject, float>{ true,  TestObject(3), 3.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(4), 4.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(5), 5.0f},
-			tuple<bool, TestObject, float>{ true,  TestObject(6), 6.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(7), 7.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(8), 8.0f},
-			tuple<bool, TestObject, float>{ true,  TestObject(9), 9.0f}
+			{ true,  TestObject(0), 0.0f},
+			{ false, TestObject(1), 1.0f},
+			{ false, TestObject(2), 2.0f},
+			{ true,  TestObject(3), 3.0f},
+			{ false, TestObject(4), 4.0f},
+			{ false, TestObject(5), 5.0f},
+			{ true,  TestObject(6), 6.0f},
+			{ false, TestObject(7), 7.0f},
+			{ false, TestObject(8), 8.0f},
+			{ true,  TestObject(9), 9.0f}
 			});
 
 		// copy entire tuple_vector in ctor
@@ -1054,16 +1054,16 @@ int TestFixedTupleVectorVariant()
 		{
 			fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> ctorFromAssignment;
 			ctorFromAssignment = {
-				tuple<bool, TestObject, float>{ true,  TestObject(0), 0.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(1), 1.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(2), 2.0f},
-				tuple<bool, TestObject, float>{ true,  TestObject(3), 3.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(4), 4.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(5), 5.0f},
-				tuple<bool, TestObject, float>{ true,  TestObject(6), 6.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(7), 7.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(8), 8.0f},
-				tuple<bool, TestObject, float>{ true,  TestObject(9), 9.0f}
+				{ true,  TestObject(0), 0.0f},
+				{ false, TestObject(1), 1.0f},
+				{ false, TestObject(2), 2.0f},
+				{ true,  TestObject(3), 3.0f},
+				{ false, TestObject(4), 4.0f},
+				{ false, TestObject(5), 5.0f},
+				{ true,  TestObject(6), 6.0f},
+				{ false, TestObject(7), 7.0f},
+				{ false, TestObject(8), 8.0f},
+				{ true,  TestObject(9), 9.0f}
 			};
 			EATEST_VERIFY(ctorFromAssignment.size() == 10);
 			EATEST_VERIFY(ctorFromAssignment.validate());

--- a/test/source/TestFixedTupleVector.cpp
+++ b/test/source/TestFixedTupleVector.cpp
@@ -490,6 +490,80 @@ int TestFixedTupleVectorVariant()
 			EATEST_VERIFY(testVec.validate());
 		}
 
+		// test insert with initList
+		{
+			fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> testVec;
+			tuple<bool, TestObject, float> testTup;
+			testVec.reserve(10);
+
+			// test insert on empty vector that doesn't cause growth
+			testTup = tuple<bool, TestObject, float>(true, TestObject(3), 3.0f);
+			testVec.insert(testVec.begin(), {
+				tuple<bool, TestObject, float>{true, TestObject(3), 3.0f},
+				testTup,
+				tuple<bool, TestObject, float>{true, TestObject(3), 3.0f}
+				});
+			EATEST_VERIFY(testVec.size() == 3);
+
+			// test insert to end of vector that doesn't cause growth
+			testTup = tuple<bool, TestObject, float>(true, TestObject(5), 5.0f);
+			testVec.insert(testVec.end(), {
+				tuple<bool, TestObject, float>{true, TestObject(5), 5.0f},
+				testTup,
+				tuple<bool, TestObject, float>{true, TestObject(5), 5.0f}
+				});
+			EATEST_VERIFY(testVec.size() == 6);
+
+			// test insert to middle of vector that doesn't cause growth
+			testTup = tuple<bool, TestObject, float>(true, TestObject(4), 4.0f);
+			testVec.insert(testVec.begin() + 3, {
+				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f},
+				testTup,
+				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f}
+				});
+			EATEST_VERIFY(testVec.size() == 9);
+			EATEST_VERIFY(testVec.capacity() == 10);
+
+			// test insert to end of vector that causes growth
+			testTup = tuple<bool, TestObject, float>(true, TestObject(6), 6.0f);
+			testVec.insert(testVec.end(), {
+				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f},
+				testTup,
+				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f}
+				});
+			EATEST_VERIFY(testVec.size() == 12);
+			testVec.shrink_to_fit();
+			EATEST_VERIFY(testVec.capacity() == 12);
+
+			// test insert to beginning of vector that causes growth
+			testTup = tuple<bool, TestObject, float>(true, TestObject(1), 1.0f);
+			testVec.insert(testVec.begin(), {
+				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f},
+				testTup,
+				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f}
+				});
+			EATEST_VERIFY(testVec.size() == 15);
+			testVec.shrink_to_fit();
+			EATEST_VERIFY(testVec.capacity() == 15);
+
+			// test insert to middle of vector that causes growth
+			testTup = tuple<bool, TestObject, float>(true, TestObject(2), 2.0f);
+			testVec.insert(testVec.begin() + 3, {
+				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f},
+				testTup,
+				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f
+			} });
+			EATEST_VERIFY(testVec.size() == 18);
+			testVec.shrink_to_fit();
+			EATEST_VERIFY(testVec.capacity() == 18);
+
+			for (unsigned int i = 0; i < testVec.size(); ++i)
+			{
+				EATEST_VERIFY(testVec.get<1>()[i] == TestObject(i / 3 + 1));
+			}
+			EATEST_VERIFY(testVec.validate());
+		}
+
 		// test insert with rvalue args
 		{
 			fixed_tuple_vector<nodeCount, bEnableOverflow, int, MoveOnlyType, TestObject> testVec;
@@ -758,6 +832,47 @@ int TestFixedTupleVectorVariant()
 			}
 			EATEST_VERIFY(TestObject::sTOCount == 10 + 20);
 		}
+
+		{
+			fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> testVec;
+
+			// test assign from initList that grows the capacity
+			testVec.assign({
+				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f },
+				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f },
+				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f }
+				});
+			EATEST_VERIFY(testVec.size() == 3);
+			for (unsigned int i = 0; i < testVec.size(); ++i)
+			{
+				EATEST_VERIFY(testVec[i] == make_tuple(true, TestObject(1), 1.0f));
+			}
+			EATEST_VERIFY(TestObject::sTOCount == 3);
+
+			// test assign from initList that shrinks the vector
+			testVec.assign({
+				tuple<bool, TestObject, float>{ true, TestObject(2), 2.0f }
+				});
+			EATEST_VERIFY(testVec.size() == 1);
+			for (unsigned int i = 0; i < testVec.size(); ++i)
+			{
+				EATEST_VERIFY(testVec[i] == make_tuple(true, TestObject(2), 2.0f));
+			}
+			EATEST_VERIFY(TestObject::sTOCount == 1);
+
+			// test assign from initList for when there's enough capacity
+			testVec.assign({
+				tuple<bool, TestObject, float>{ true, TestObject(3), 3.0f },
+				tuple<bool, TestObject, float>{ true, TestObject(3), 3.0f }
+				});
+			EATEST_VERIFY(testVec.size() == 2);
+			for (unsigned int i = 0; i < testVec.size(); ++i)
+			{
+				EATEST_VERIFY(testVec[i] == make_tuple(true, TestObject(3), 3.0f));
+			}
+			EATEST_VERIFY(TestObject::sTOCount == 2);
+		}
+
 		EATEST_VERIFY(TestObject::IsClear());
 		TestObject::Reset();
 	}
@@ -881,12 +996,23 @@ int TestFixedTupleVectorVariant()
 		EASTLAllocatorType ma;
 		EASTLAllocatorType otherMa;
 		TestObject::Reset();
-		fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> srcVec;
-		for (int i = 0; i < 10; ++i)
-		{
-			srcVec.push_back(i % 3 == 0, TestObject(i), (float)i);
-		}
 
+		// test ctor via initlist to prime srcVec. Equivalent to ...
+		//		for (int i = 0; i < 10; ++i)
+		//			srcVec.push_back(i % 3 == 0, TestObject(i), (float)i);
+
+		fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> srcVec({
+			tuple<bool, TestObject, float>{ true,  TestObject(0), 0.0f},
+			tuple<bool, TestObject, float>{ false, TestObject(1), 1.0f},
+			tuple<bool, TestObject, float>{ false, TestObject(2), 2.0f},
+			tuple<bool, TestObject, float>{ true,  TestObject(3), 3.0f},
+			tuple<bool, TestObject, float>{ false, TestObject(4), 4.0f},
+			tuple<bool, TestObject, float>{ false, TestObject(5), 5.0f},
+			tuple<bool, TestObject, float>{ true,  TestObject(6), 6.0f},
+			tuple<bool, TestObject, float>{ false, TestObject(7), 7.0f},
+			tuple<bool, TestObject, float>{ false, TestObject(8), 8.0f},
+			tuple<bool, TestObject, float>{ true,  TestObject(9), 9.0f}
+			});
 
 		// copy entire tuple_vector in ctor
 		{
@@ -912,6 +1038,31 @@ int TestFixedTupleVectorVariant()
 				EATEST_VERIFY(ctorFromAssignment.template get<0>()[i] == (i % 3 == 0));
 				EATEST_VERIFY(ctorFromAssignment.template get<1>()[i] == TestObject(i));
 				EATEST_VERIFY(ctorFromAssignment.template get<2>()[i] == (float)i);
+			}
+		}
+
+		// copy entire tuple_vector via assignment of init-list
+		{
+			fixed_tuple_vector<nodeCount, bEnableOverflow, bool, TestObject, float> ctorFromAssignment;
+			ctorFromAssignment = {
+				tuple<bool, TestObject, float>{ true,  TestObject(0), 0.0f},
+				tuple<bool, TestObject, float>{ false, TestObject(1), 1.0f},
+				tuple<bool, TestObject, float>{ false, TestObject(2), 2.0f},
+				tuple<bool, TestObject, float>{ true,  TestObject(3), 3.0f},
+				tuple<bool, TestObject, float>{ false, TestObject(4), 4.0f},
+				tuple<bool, TestObject, float>{ false, TestObject(5), 5.0f},
+				tuple<bool, TestObject, float>{ true,  TestObject(6), 6.0f},
+				tuple<bool, TestObject, float>{ false, TestObject(7), 7.0f},
+				tuple<bool, TestObject, float>{ false, TestObject(8), 8.0f},
+				tuple<bool, TestObject, float>{ true,  TestObject(9), 9.0f}
+			};
+			EATEST_VERIFY(ctorFromAssignment.size() == 10);
+			EATEST_VERIFY(ctorFromAssignment.validate());
+			for (int i = 0; i < 10; ++i)
+			{
+				EATEST_VERIFY(ctorFromAssignment.get<0>()[i] == (i % 3 == 0));
+				EATEST_VERIFY(ctorFromAssignment.get<1>()[i] == TestObject(i));
+				EATEST_VERIFY(ctorFromAssignment.get<2>()[i] == (float)i);
 			}
 		}
 

--- a/test/source/TestFixedTupleVector.cpp
+++ b/test/source/TestFixedTupleVector.cpp
@@ -568,7 +568,7 @@ int TestFixedTupleVectorVariant()
 
 			for (unsigned int i = 0; i < testVec.size(); ++i)
 			{
-				EATEST_VERIFY(testVec.get<1>()[i] == TestObject(i / 3 + 1));
+				EATEST_VERIFY(testVec.template get<1>()[i] == TestObject(i / 3 + 1));
 			}
 			EATEST_VERIFY(testVec.validate());
 		}
@@ -1069,9 +1069,9 @@ int TestFixedTupleVectorVariant()
 			EATEST_VERIFY(ctorFromAssignment.validate());
 			for (int i = 0; i < 10; ++i)
 			{
-				EATEST_VERIFY(ctorFromAssignment.get<0>()[i] == (i % 3 == 0));
-				EATEST_VERIFY(ctorFromAssignment.get<1>()[i] == TestObject(i));
-				EATEST_VERIFY(ctorFromAssignment.get<2>()[i] == (float)i);
+				EATEST_VERIFY(ctorFromAssignment.template get<0>()[i] == (i % 3 == 0));
+				EATEST_VERIFY(ctorFromAssignment.template get<1>()[i] == TestObject(i));
+				EATEST_VERIFY(ctorFromAssignment.template get<2>()[i] == (float)i);
 			}
 		}
 

--- a/test/source/TestFixedTupleVector.cpp
+++ b/test/source/TestFixedTupleVector.cpp
@@ -522,7 +522,7 @@ int TestFixedTupleVectorVariant()
 				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 9);
-			EATEST_VERIFY(testVec.capacity() == 10);
+			EATEST_VERIFY(testVec.capacity() == 10 || testVec.capacity() == nodeCount);
 
 			// test insert to end of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(6), 6.0f);
@@ -532,8 +532,11 @@ int TestFixedTupleVectorVariant()
 				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 12);
-			testVec.shrink_to_fit();
-			EATEST_VERIFY(testVec.capacity() == 12);
+			if (testVec.has_overflowed())
+			{
+				testVec.shrink_to_fit();
+			}
+			EATEST_VERIFY(testVec.capacity() == 12 || testVec.capacity() == nodeCount);
 
 			// test insert to beginning of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(1), 1.0f);
@@ -543,8 +546,11 @@ int TestFixedTupleVectorVariant()
 				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 15);
-			testVec.shrink_to_fit();
-			EATEST_VERIFY(testVec.capacity() == 15);
+			if (testVec.has_overflowed())
+			{
+				testVec.shrink_to_fit();
+			}
+			EATEST_VERIFY(testVec.capacity() == 15 || testVec.capacity() == nodeCount);
 
 			// test insert to middle of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(2), 2.0f);
@@ -554,8 +560,11 @@ int TestFixedTupleVectorVariant()
 				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f
 			} });
 			EATEST_VERIFY(testVec.size() == 18);
-			testVec.shrink_to_fit();
-			EATEST_VERIFY(testVec.capacity() == 18);
+			if (testVec.has_overflowed())
+			{
+				testVec.shrink_to_fit();
+			}
+			EATEST_VERIFY(testVec.capacity() == 18 || testVec.capacity() == nodeCount);
 
 			for (unsigned int i = 0; i < testVec.size(); ++i)
 			{

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -8,13 +8,6 @@ EA_DISABLE_VC_WARNING(4623 4625 4413 4510)
 
 #include <EASTL/tuple.h>
 
-
-#include <tuple>
-#include <vector>
-
-#pragma warning ( disable : 4244 )
-
-
 #if EASTL_TUPLE_ENABLED
 
 namespace TestTupleInternal

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -8,6 +8,13 @@ EA_DISABLE_VC_WARNING(4623 4625 4413 4510)
 
 #include <EASTL/tuple.h>
 
+
+#include <tuple>
+#include <vector>
+
+#pragma warning ( disable : 4244 )
+
+
 #if EASTL_TUPLE_ENABLED
 
 namespace TestTupleInternal
@@ -446,6 +453,29 @@ int TestTuple()
 			//     EATEST_VERIFY(result == 10);
 			// }
 		}
+	}
+
+	// Compilation test to make sure that the conditionally-explicit cast works
+	{
+		eastl::tuple<int, float, TestObject> arrayTup[] = {
+			{1, 1.0f, TestObject(1)},
+			{2, 2.0f, TestObject(2)},
+			{3, 3.0f, TestObject(3)},
+			{4, 4.0f, TestObject(4)}
+		};
+
+#if false
+		// the following code should not compile with conditionally-explicit behaviour (but does with fully implicit behaviour)
+		eastl::tuple<eastl::vector<float>, float> arrayOfArrayTup[] = {
+			{1.0f, 1.0f},
+			{2.0f, 2.0f}
+		};
+
+		eastl::tuple<eastl::vector<int>, float> arrayOfArrayTup2[] = {
+			{1, 1.0f},
+			{2, 2.0f}
+		};
+#endif
 	}
 
 	return nErrorCount;

--- a/test/source/TestTupleVector.cpp
+++ b/test/source/TestTupleVector.cpp
@@ -488,27 +488,27 @@ int TestTupleVector()
 			// test insert on empty vector that doesn't cause growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(3), 3.0f);
 			testVec.insert(testVec.begin(), { 
-				tuple<bool, TestObject, float>{true, TestObject(3), 3.0f},
+				{true, TestObject(3), 3.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(3), 3.0f}
+				{true, TestObject(3), 3.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 3);
 
 			// test insert to end of vector that doesn't cause growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(5), 5.0f);
 			testVec.insert(testVec.end(), { 
-				tuple<bool, TestObject, float>{true, TestObject(5), 5.0f}, 
+				{true, TestObject(5), 5.0f}, 
 				testTup, 
-				tuple<bool, TestObject, float>{true, TestObject(5), 5.0f} 
+				{true, TestObject(5), 5.0f} 
 				});
 			EATEST_VERIFY(testVec.size() == 6);
 
 			// test insert to middle of vector that doesn't cause growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(4), 4.0f);
 			testVec.insert(testVec.begin() + 3, {
-				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f}, 
+				{true, TestObject(4), 4.0f}, 
 				testTup, 
-				tuple<bool, TestObject, float>{true, TestObject(4), 4.0f}
+				{true, TestObject(4), 4.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 9);
 			EATEST_VERIFY(testVec.capacity() == 10);
@@ -516,9 +516,9 @@ int TestTupleVector()
 			// test insert to end of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(6), 6.0f);
 			testVec.insert(testVec.end(), { 
-				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f},
+				{true, TestObject(6), 6.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(6), 6.0f}
+				{true, TestObject(6), 6.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 12);
 			testVec.shrink_to_fit();
@@ -527,9 +527,9 @@ int TestTupleVector()
 			// test insert to beginning of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(1), 1.0f);
 			testVec.insert(testVec.begin(), { 
-				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f}, 
+				{true, TestObject(1), 1.0f}, 
 				testTup, 
-				tuple<bool, TestObject, float>{true, TestObject(1), 1.0f}
+				{true, TestObject(1), 1.0f}
 				});
 			EATEST_VERIFY(testVec.size() == 15);
 			testVec.shrink_to_fit();
@@ -538,9 +538,9 @@ int TestTupleVector()
 			// test insert to middle of vector that causes growth
 			testTup = tuple<bool, TestObject, float>(true, TestObject(2), 2.0f);
 			testVec.insert(testVec.begin() + 3, { 
-				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f},
+				{true, TestObject(2), 2.0f},
 				testTup,
-				tuple<bool, TestObject, float>{true, TestObject(2), 2.0f
+				{true, TestObject(2), 2.0f
 				} });
 			EATEST_VERIFY(testVec.size() == 18);
 			testVec.shrink_to_fit();
@@ -800,9 +800,9 @@ int TestTupleVector()
 
 			// test assign from initList that grows the capacity
 			testVec.assign({
-				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f }, 
-				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f },
-				tuple<bool, TestObject, float>{ true, TestObject(1), 1.0f }
+				{ true, TestObject(1), 1.0f }, 
+				{ true, TestObject(1), 1.0f },
+				{ true, TestObject(1), 1.0f }
 				});
 			EATEST_VERIFY(testVec.size() == 3);
 			for (unsigned int i = 0; i < testVec.size(); ++i)
@@ -813,7 +813,7 @@ int TestTupleVector()
 
 			// test assign from initList that shrinks the vector
 			testVec.assign({
-				tuple<bool, TestObject, float>{ true, TestObject(2), 2.0f }
+				{ true, TestObject(2), 2.0f }
 				});
 			EATEST_VERIFY(testVec.size() == 1);
 			for (unsigned int i = 0; i < testVec.size(); ++i)
@@ -824,8 +824,8 @@ int TestTupleVector()
 
 			// test assign from initList for when there's enough capacity
 			testVec.assign({
-				tuple<bool, TestObject, float>{ true, TestObject(3), 3.0f },
-				tuple<bool, TestObject, float>{ true, TestObject(3), 3.0f }
+				{ true, TestObject(3), 3.0f },
+				{ true, TestObject(3), 3.0f }
 				});
 			EATEST_VERIFY(testVec.size() == 2);
 			for (unsigned int i = 0; i < testVec.size(); ++i)
@@ -960,16 +960,16 @@ int TestTupleVector()
 
 		// test ctor via initlist to prime srcVec
 		tuple_vector<bool, TestObject, float> srcVec({
-			tuple<bool, TestObject, float>{ true,  TestObject(0), 0.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(1), 1.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(2), 2.0f},
-			tuple<bool, TestObject, float>{ true,  TestObject(3), 3.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(4), 4.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(5), 5.0f},
-			tuple<bool, TestObject, float>{ true,  TestObject(6), 6.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(7), 7.0f},
-			tuple<bool, TestObject, float>{ false, TestObject(8), 8.0f},
-			tuple<bool, TestObject, float>{ true,  TestObject(9), 9.0f}
+			{ true,  TestObject(0), 0.0f},
+			{ false, TestObject(1), 1.0f},
+			{ false, TestObject(2), 2.0f},
+			{ true,  TestObject(3), 3.0f},
+			{ false, TestObject(4), 4.0f},
+			{ false, TestObject(5), 5.0f},
+			{ true,  TestObject(6), 6.0f},
+			{ false, TestObject(7), 7.0f},
+			{ false, TestObject(8), 8.0f},
+			{ true,  TestObject(9), 9.0f}
 			});
 
 		// copy entire tuple_vector in ctor
@@ -1003,16 +1003,16 @@ int TestTupleVector()
 		{
 			tuple_vector<bool, TestObject, float> ctorFromAssignment;
 			ctorFromAssignment = { 
-				tuple<bool, TestObject, float>{ true,  TestObject(0), 0.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(1), 1.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(2), 2.0f},
-				tuple<bool, TestObject, float>{ true,  TestObject(3), 3.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(4), 4.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(5), 5.0f},
-				tuple<bool, TestObject, float>{ true,  TestObject(6), 6.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(7), 7.0f},
-				tuple<bool, TestObject, float>{ false, TestObject(8), 8.0f},
-				tuple<bool, TestObject, float>{ true,  TestObject(9), 9.0f}
+				{ true,  TestObject(0), 0.0f},
+				{ false, TestObject(1), 1.0f},
+				{ false, TestObject(2), 2.0f},
+				{ true,  TestObject(3), 3.0f},
+				{ false, TestObject(4), 4.0f},
+				{ false, TestObject(5), 5.0f},
+				{ true,  TestObject(6), 6.0f},
+				{ false, TestObject(7), 7.0f},
+				{ false, TestObject(8), 8.0f},
+				{ true,  TestObject(9), 9.0f}
 			};
 			EATEST_VERIFY(ctorFromAssignment.size() == 10);
 			EATEST_VERIFY(ctorFromAssignment.validate());


### PR DESCRIPTION
This PR resolves "issue"/task https://github.com/electronicarts/EASTL/issues/204 by adding initializer list support to tuple_vector. This includes the following:

- Implementations for the following functions:
```
tuple_vector<Ts...>(std::initializer_list<value_tuple> iList)
operator=(std::initializer_list<value_tuple> iList)
void assign(std::initializer_list<value_tuple> iList)
const_iterator insert(const_iterator pos, std::initializer_list<value_tuple> iList)
```
- ...which are actually all implemented over the following functions, which may be usable for conversion of, say, vectors of tuples into tuple_vectors 😉
```
tuple_vector<Ts...>(const value_tuple* begin, const value_tuple* end)
void assign(const value_tuple* begin, const value_tuple* end)
const_iterator insert(const_iterator pos, const value_tuple* begin, const value_tuple* end)
```
- Tuple construction is now conditionally explicit (as per a small cpp17 change), i.e. an implicit constructor is utilized if all of the types provided for construction are an exact match for the tuple's definition


Note that this change is independent of https://github.com/electronicarts/EASTL/pull/203 and there *will* be a conflict if a merge is attempted. After this one or https://github.com/electronicarts/EASTL/pull/203 are merged, the other will have to be fixed up due to the new ctors here still referencing the non-compressed-pair version of mAllocator.