### PR TITLE
Misc build fixes

### DIFF
--- a/include/EASTL/internal/char_traits.h
+++ b/include/EASTL/internal/char_traits.h
@@ -17,9 +17,11 @@
 EA_ONCE()
 
 #include <EASTL/internal/config.h>
+#include <EASTL/type_traits.h>
 
 EA_DISABLE_ALL_VC_WARNINGS()
 #include <ctype.h>              // toupper, etc.
+#include <string.h>             // memset, etc.
 EA_RESTORE_ALL_VC_WARNINGS()
 
 namespace eastl

--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -2973,7 +2973,8 @@ namespace eastl
 	inline int basic_string<T, Allocator>::compare(size_type pos1, size_type n1, const this_type& x, size_type pos2, size_type n2) const
 	{
 		#if EASTL_STRING_OPT_RANGE_ERRORS
-			if(EASTL_UNLIKELY((pos1 > (size_type)(mpEnd - mpBegin)) || (pos2 > (size_type)(x.mpEnd - x.mpBegin))))
+			if(EASTL_UNLIKELY((pos1 > (size_type)(internalLayout().EndPtr() - internalLayout().BeginPtr())) ||
+			                  (pos2 > (size_type)(x.internalLayout().EndPtr() - x.internalLayout().BeginPtr()))))
 				ThrowRangeException();
 		#endif
 

--- a/include/EASTL/string_view.h
+++ b/include/EASTL/string_view.h
@@ -18,7 +18,15 @@
 
 #include <EASTL/internal/config.h>
 #include <EASTL/internal/char_traits.h>
+#include <EASTL/algorithm.h>
+#include <EASTL/iterator.h>
 #include <EASTL/numeric_limits.h>
+
+#if EASTL_EXCEPTIONS_ENABLED
+	EA_DISABLE_ALL_VC_WARNINGS()
+	#include <stdexcept> // std::out_of_range.
+	EA_RESTORE_ALL_VC_WARNINGS()
+#endif
 
 EA_DISABLE_VC_WARNING(4814)
 

--- a/scripts/CMake/CommonCppFlags.cmake
+++ b/scripts/CMake/CommonCppFlags.cmake
@@ -20,7 +20,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.1")
         message(FATAL_ERROR "Building with a Apple clang version less than 3.1 is not supported.")
     endif()
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # non-Apple clangs uses different versioning.
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_SIMULATE_ID MATCHES "MSVC") # clang, but not clang-cl.
+    # non-Apple clangs uses different versioning.
     if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.5.0"))
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     endif()

--- a/test/packages/EABase/include/Common/EABase/config/eacompiler.h
+++ b/test/packages/EABase/include/Common/EABase/config/eacompiler.h
@@ -16,6 +16,7 @@
  *     EA_COMPILER_QNX
  *     EA_COMPILER_GREEN_HILLS
  *     EA_COMPILER_CLANG
+ *     EA_COMPILER_CLANG_CL
  *     
  *     EA_COMPILER_VERSION = <integer>
  *     EA_COMPILER_NAME = <string>
@@ -313,7 +314,8 @@
 		#define EA_COMPILER_NAME    "RVCT"
 	  //#define EA_COMPILER_STRING (defined below)
 
-	#elif defined(__clang__)
+	// Clang's GCC-compatible driver.
+	#elif defined(__clang__) && !defined(_MSC_VER)
 		#define EA_COMPILER_CLANG   1
 		#define EA_COMPILER_VERSION (__clang_major__ * 100 + __clang_minor__)
 		#define EA_COMPILER_NAME    "clang"
@@ -392,6 +394,11 @@
 		#define EA_COMPILER_VERSION _MSC_VER
 		#define EA_COMPILER_NAME "Microsoft Visual C++"
 	  //#define EA_COMPILER_STRING (defined below)
+
+		#if defined(__clang__)
+			// Clang's MSVC-compatible driver.
+			#define EA_COMPILER_CLANG_CL 1
+		#endif
 
 		#define EA_STANDARD_LIBRARY_MSVC 1
 		#define EA_STANDARD_LIBRARY_MICROSOFT 1

--- a/test/packages/EABase/include/Common/EABase/config/eacompilertraits.h
+++ b/test/packages/EABase/include/Common/EABase/config/eacompilertraits.h
@@ -770,7 +770,7 @@
 	//     EA_RESTORE_CLANG_WARNING()
 	//
 	#ifndef EA_DISABLE_CLANG_WARNING
-		#if defined(EA_COMPILER_CLANG)
+		#if defined(EA_COMPILER_CLANG) || defined(EA_COMPILER_CLANG_CL)
 			#define EACLANGWHELP0(x) #x
 			#define EACLANGWHELP1(x) EACLANGWHELP0(clang diagnostic ignored x)
 			#define EACLANGWHELP2(x) EACLANGWHELP1(#x)
@@ -784,7 +784,7 @@
 	#endif
 
 	#ifndef EA_RESTORE_CLANG_WARNING
-		#if defined(EA_COMPILER_CLANG)
+		#if defined(EA_COMPILER_CLANG) || defined(EA_COMPILER_CLANG_CL)
 			#define EA_RESTORE_CLANG_WARNING()    \
 				_Pragma("clang diagnostic pop")
 		#else
@@ -812,7 +812,7 @@
 	//     EA_DISABLE_CLANG_WARNING_AS_ERROR()
 	//
 	#ifndef EA_ENABLE_CLANG_WARNING_AS_ERROR
-		#if defined(EA_COMPILER_CLANG)
+		#if defined(EA_COMPILER_CLANG) || defined(EA_COMPILER_CLANG_CL)
 			#define EACLANGWERRORHELP0(x) #x
 			#define EACLANGWERRORHELP1(x) EACLANGWERRORHELP0(clang diagnostic error x)
 			#define EACLANGWERRORHELP2(x) EACLANGWERRORHELP1(#x)
@@ -826,7 +826,7 @@
 	#endif
 
 	#ifndef EA_DISABLE_CLANG_WARNING_AS_ERROR
-		#if defined(EA_COMPILER_CLANG)
+		#if defined(EA_COMPILER_CLANG) || defined(EA_COMPILER_CLANG_CL)
 			#define EA_DISABLE_CLANG_WARNING_AS_ERROR()    \
 				_Pragma("clang diagnostic pop")
 		#else


### PR DESCRIPTION
A CMake script added GCC-style flags when using clang-cl. This caused an unknown argument warning during compilation.