### PR TITLE
Fixing issue where tuple_vector::operator= for init-list was not used/compiled

### DIFF
--- a/include/EASTL/bonus/fixed_tuple_vector.h
+++ b/include/EASTL/bonus/fixed_tuple_vector.h
@@ -146,7 +146,7 @@ public:
 
 	this_type& operator=(const this_type& other)
 	{
-		(base_type&)(*this) = (base_type&)other;
+		base_type::operator=(other);
 		return *this;
 	}
 
@@ -156,6 +156,12 @@ public:
 		// OK to call DoInitFromIterator in a non-ctor scenario because clear() reset everything, more-or-less
 		base_type::DoInitFromIterator(make_move_iterator(other.begin()), make_move_iterator(other.end()));
 		other.clear();
+		return *this;
+	}
+
+	this_type& operator=(std::initializer_list<typename base_type::value_tuple> iList)
+	{
+		base_type::operator=(iList);
 		return *this;
 	}
 

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -1199,7 +1199,7 @@ public:
 
 	this_type& operator=(std::initializer_list<value_tuple> iList) 
 	{
-		assign(iList.begin, iList.end());
+		assign(iList.begin(), iList.end());
 		return *this; 
 	}
 
@@ -1499,8 +1499,17 @@ inline void swap(TupleVecInternal::TupleVecImpl<AllocatorA, make_index_sequence<
 template <typename... Ts>
 class tuple_vector : public TupleVecInternal::TupleVecImpl<EASTLAllocatorType, make_index_sequence<sizeof...(Ts)>, Ts...>
 {
+	typedef tuple_vector<Ts...> this_type;
 	typedef TupleVecInternal::TupleVecImpl<EASTLAllocatorType, make_index_sequence<sizeof...(Ts)>, Ts...> base_type;
 	using base_type::base_type;
+
+public:
+
+	this_type& operator=(std::initializer_list<typename base_type::value_tuple> iList) 
+	{
+		base_type::operator=(iList);
+		return *this;
+	}
 };
 
 // Variant of tuple_vector that allows a user-defined allocator type (can't mix default template params with variadics)
@@ -1508,8 +1517,17 @@ template <typename AllocatorType, typename... Ts>
 class tuple_vector_alloc
 	: public TupleVecInternal::TupleVecImpl<AllocatorType, make_index_sequence<sizeof...(Ts)>, Ts...>
 {
+	typedef tuple_vector_alloc<AllocatorType, Ts...> this_type;
 	typedef TupleVecInternal::TupleVecImpl<AllocatorType, make_index_sequence<sizeof...(Ts)>, Ts...> base_type;
 	using base_type::base_type;
+
+public:
+
+	this_type& operator=(std::initializer_list<typename base_type::value_tuple> iList)
+	{
+		base_type::operator=(iList);
+		return *this;
+	}
 };
 
 }  // namespace eastl


### PR DESCRIPTION
This was not previously not an issue because the operator= for rvalue-ref of tuple was being invoked implicitly.

This was noticed because tuple_vector::operator=(std::initializer_list<value_tuple> iList) should not have been able to compile. "Assign" for init-list was still being called by other unit-tests, though.