### PR TITLE
Optimized the implementation of 'merge' to avoid the overhead of calling copy twice (when only one copy has non-zero length).

### DIFF
--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -191,7 +191,14 @@ namespace eastl
 			++result;
 		}
 
-		return eastl::copy(first2, last2, eastl::copy(first1, last1, result));
+		if (first1 == last1)
+		{
+			return eastl::copy(first2, last2, result);
+		}
+		else
+		{
+			return eastl::copy(first1, last1, result);
+		}
 	}
 
 	template <typename InputIterator1, typename InputIterator2, typename OutputIterator>

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -191,6 +191,10 @@ namespace eastl
 			++result;
 		}
 
+		// Check which list is empty and explicitly copy remaining items from the other list.
+		// For performance reasons, only a single copy operation is invoked to avoid the potential overhead
+		// introduced by chaining two copy operations together.  Even if a copy is of zero size there can
+		// be overhead from calling memmove with a zero size copy.
 		if (first1 == last1)
 		{
 			return eastl::copy(first2, last2, result);


### PR DESCRIPTION
This is a fairly minor change, but it gives ~6.5% reduction in time to run the merge_sort/merge_sort_buffer benchmarks on my tests (using MSVC release builds on PC).  The change makes sure that eastl::copy is only invoked once.  Previously copy was called twice even though one of the copies has zero length.  However, this 0 length copy may still have overhead (e.g. calling a non-inline memmove with zero length).