### PR TITLE
Fixing ADL manually

### DIFF
--- a/include/EASTL/fixed_vector.h
+++ b/include/EASTL/fixed_vector.h
@@ -256,7 +256,7 @@ namespace eastl
 
 		mpBegin = mpEnd = (value_type*)&mBuffer.buffer[0];
 		internalCapacityPtr() = mpBegin + nodeCount;
-		base_type::template DoAssign<move_iterator<iterator>, true>(make_move_iterator(x.begin()), make_move_iterator(x.end()), false_type());
+		base_type::template DoAssign<move_iterator<iterator>, true>(eastl::make_move_iterator(x.begin()), eastl::make_move_iterator(x.end()), false_type());
 	}
 
 


### PR DESCRIPTION
This forces the namespace check in eastl namespace for this particular situation.