### PR TITLE
Adding `get_allocator()` method to `tuple_vector` for parity with other containers

### DIFF
--- a/include/EASTL/bonus/fixed_tuple_vector.h
+++ b/include/EASTL/bonus/fixed_tuple_vector.h
@@ -65,7 +65,7 @@ public:
 	fixed_tuple_vector(this_type&& x)
 		: base_type(fixed_allocator_type(mBuffer.buffer), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
 	{ 
-		base_type::internalAllocator().copy_overflow_allocator(x.internalAllocator());
+		base_type::get_allocator().copy_overflow_allocator(x.get_allocator());
 		base_type::DoInitFromIterator(make_move_iterator(x.begin()), make_move_iterator(x.end()));
 		x.clear();
 	}
@@ -80,7 +80,7 @@ public:
 	fixed_tuple_vector(const this_type& x)
 		: base_type(fixed_allocator_type(mBuffer.buffer), mBuffer.buffer, nodeCount, fixed_allocator_type::kNodeSize)
 	{ 
-		base_type::internalAllocator().copy_overflow_allocator(x.internalAllocator());
+		base_type::get_allocator().copy_overflow_allocator(x.get_allocator());
 		base_type::DoInitFromIterator(x.begin(), x.end());
 	}
 
@@ -192,7 +192,7 @@ public:
 	// Returns the value of the bEnableOverflow template parameter.
 	bool can_overflow() const { return bEnableOverflow; }
 
-	const overflow_allocator_type& get_overflow_allocator() const { return base_type::internalAllocator().get_overflow_allocator(); }
+	const overflow_allocator_type& get_overflow_allocator() const { return base_type::get_allocator().get_overflow_allocator(); }
 };
 
 

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -165,7 +165,7 @@ struct TupleRecurser<>
 		// If n is zero, then we allocate no memory and just return NULL. 
 		// This is fine, as our default ctor initializes with NULL pointers. 
 		size_type alignment = TupleRecurser<VecTypes...>::GetTotalAlignment();
-		void* ptr = capacity ? allocate_memory(vec.internalAllocator(), offset, alignment, 0) : nullptr;
+		void* ptr = capacity ? allocate_memory(vec.get_allocator(), offset, alignment, 0) : nullptr;
 
 	#if EASTL_ASSERT_ENABLED
 		if (EASTL_UNLIKELY((size_type)ptr & (alignment - 1)) != 0)
@@ -477,7 +477,7 @@ public:
 	{}
 
 	TupleVecImpl(this_type&& x)
-		: mDataSizeAndAllocator(0, eastl::move(x.internalAllocator()))
+		: mDataSizeAndAllocator(0, eastl::move(x.get_allocator()))
 	{
 		swap(x);
 	}
@@ -485,7 +485,7 @@ public:
 	TupleVecImpl(this_type&& x, const Allocator& allocator) 
 		: mDataSizeAndAllocator(0, allocator)
 	{
-		if (internalAllocator() == x.internalAllocator()) // If allocators are equivalent, then we can safely swap member-by-member
+		if (get_allocator() == x.get_allocator()) // If allocators are equivalent, then we can safely swap member-by-member
 		{
 			swap(x);
 		}
@@ -497,7 +497,7 @@ public:
 	}
 
 	TupleVecImpl(const this_type& x) 
-		: mDataSizeAndAllocator(0, x.internalAllocator())
+		: mDataSizeAndAllocator(0, x.get_allocator())
 	{
 		DoInitFromIterator(x.begin(), x.end());
 	}
@@ -571,14 +571,14 @@ public:
 	{ 
 		swallow((eastl::destruct(TupleVecLeaf<Indices, Ts>::mpData, TupleVecLeaf<Indices, Ts>::mpData + mNumElements), 0)...);
 		if (mpData)
-			EASTLFree(internalAllocator(), mpData, internalDataSize()); 
+			EASTLFree(get_allocator(), mpData, internalDataSize()); 
 	}
 
 	void assign(size_type n, const Ts&... args)
 	{
 		if (n > mNumCapacity)
 		{
-			this_type temp(n, args..., internalAllocator()); // We have little choice but to reallocate with new memory.
+			this_type temp(n, args..., get_allocator()); // We have little choice but to reallocate with new memory.
 			swap(temp);
 		}
 		else if (n > mNumElements) // If n > mNumElements ...
@@ -605,7 +605,7 @@ public:
 		size_type newNumElements = last - first;
 		if (newNumElements > mNumCapacity)
 		{
-			this_type temp(first, last, internalAllocator());
+			this_type temp(first, last, get_allocator());
 			swap(temp);
 		}
 		else
@@ -642,7 +642,7 @@ public:
 		size_type newNumElements = last - first;
 		if (newNumElements > mNumCapacity)
 		{
-			this_type temp(first, last, internalAllocator());
+			this_type temp(first, last, get_allocator());
 			swap(temp);
 		}
 		else
@@ -732,7 +732,7 @@ public:
 				swallow(::new ((Ts*)ppNewLeaf[Indices] + firstIdx) Ts(eastl::forward<Ts>(args))...);
 				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 
-				EASTLFree(internalAllocator(), mpData, internalDataSize());
+				EASTLFree(get_allocator(), mpData, internalDataSize());
 				mpData = allocation.first;
 				mNumCapacity = newCapacity;
 				internalDataSize() = allocation.second;
@@ -778,7 +778,7 @@ public:
 				swallow((eastl::uninitialized_fill_ptr((Ts*)ppNewLeaf[Indices] + firstIdx, (Ts*)ppNewLeaf[Indices] + lastIdx, args), 0)...);
 				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 		
-				EASTLFree(internalAllocator(), mpData, internalDataSize());
+				EASTLFree(get_allocator(), mpData, internalDataSize());
 				mpData = allocation.first;
 				mNumCapacity = newCapacity;
 				internalDataSize() = allocation.second;
@@ -832,7 +832,7 @@ public:
 						                       (Ts*)ppNewLeaf[Indices] + posIdx), 0)...);
 				swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 				
-				EASTLFree(internalAllocator(), mpData, internalDataSize());
+				EASTLFree(get_allocator(), mpData, internalDataSize());
 				mpData = allocation.first;
 				mNumCapacity = newCapacity;
 				internalDataSize() = allocation.second;
@@ -887,7 +887,7 @@ public:
 				// Do this after mpData is updated so that we can use new iterators
 				DoUninitializedCopyFromTupleArray(begin() + posIdx, begin() + posIdx + numToInsert, first);
 
-				EASTLFree(internalAllocator(), mpData, internalDataSize());
+				EASTLFree(get_allocator(), mpData, internalDataSize());
 				mpData = allocation.first;
 				mNumCapacity = newCapacity;
 				internalDataSize() = allocation.second;
@@ -1014,7 +1014,7 @@ public:
 
 	void shrink_to_fit()
 	{
-		this_type temp(move_iterator<iterator>(begin()), move_iterator<iterator>(end()), internalAllocator());
+		this_type temp(move_iterator<iterator>(begin()), move_iterator<iterator>(end()), get_allocator());
 		swap(temp);
 	}
 
@@ -1042,7 +1042,7 @@ public:
 		eastl::swap(mpData, x.mpData);
 		eastl::swap(mNumElements, x.mNumElements);
 		eastl::swap(mNumCapacity, x.mNumCapacity);
-		eastl::swap(internalAllocator(), x.internalAllocator());
+		eastl::swap(get_allocator(), x.get_allocator());
 		eastl::swap(internalDataSize(), x.internalDataSize());
 	}
 
@@ -1249,6 +1249,9 @@ public:
 	template <typename Iterator, typename = typename enable_if<is_iterator_wrapper<Iterator>::value, bool>::type>
 	static bool validate_iterator_pair(Iterator first, Iterator last) EA_NOEXCEPT { return validate_iterator_pair(unwrap_iterator(first), unwrap_iterator(last)); }
 
+	allocator_type& get_allocator() EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
+	const allocator_type& get_allocator() const EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
+
 protected:
 
 	void* mpData = nullptr;
@@ -1259,8 +1262,6 @@ protected:
 
 	size_type& internalDataSize() EA_NOEXCEPT { return mDataSizeAndAllocator.first(); }
 	size_type const& internalDataSize() const EA_NOEXCEPT { return mDataSizeAndAllocator.first(); }
-	allocator_type& internalAllocator() EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
-	const allocator_type& internalAllocator() const EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
 
 	friend struct TupleRecurser<>;
 	template<typename... Us>
@@ -1373,7 +1374,7 @@ protected:
 		swallow((TupleVecLeaf<Indices, Ts>::DoUninitializedMoveAndDestruct(0, oldNumElements, (Ts*)ppNewLeaf[Indices]), 0)...);
 		swallow(TupleVecLeaf<Indices, Ts>::mpData = (Ts*)ppNewLeaf[Indices]...);
 
-		EASTLFree(internalAllocator(), mpData, internalDataSize());
+		EASTLFree(get_allocator(), mpData, internalDataSize());
 		mpData = allocation.first;
 		mNumCapacity = requiredCapacity;
 		internalDataSize() = allocation.second;

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -1252,6 +1252,8 @@ public:
 	allocator_type& get_allocator() EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
 	const allocator_type& get_allocator() const EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
 
+	void set_allocator(const allocator_type& alloc) { mDataSizeAndAllocator.second() == alloc; }
+
 protected:
 
 	void* mpData = nullptr;

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -1252,7 +1252,7 @@ public:
 	allocator_type& get_allocator() EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
 	const allocator_type& get_allocator() const EA_NOEXCEPT { return mDataSizeAndAllocator.second(); }
 
-	void set_allocator(const allocator_type& alloc) { mDataSizeAndAllocator.second() == alloc; }
+	void set_allocator(const allocator_type& alloc) { mDataSizeAndAllocator.second() = alloc; }
 
 protected:
 

--- a/test/source/TestTupleVector.cpp
+++ b/test/source/TestTupleVector.cpp
@@ -1521,6 +1521,19 @@ int TestTupleVector()
 		TestObject::Reset();
 	}
 
+	// Test allocator manipulation
+	{
+		InstanceAllocator ia0((uint8_t)0), ia1((uint8_t)1);
+		tuple_vector_alloc<InstanceAllocator, int> vec(ia0);
+
+		// private vector allocator was copied from ia0 and should have matching id
+		EATEST_VERIFY(vec.get_allocator() == ia0);
+
+		// Assigning allocator
+		vec.set_allocator(ia1);
+		EATEST_VERIFY(vec.get_allocator() == ia1);
+	}
+
 	return nErrorCount;
 }
 


### PR DESCRIPTION
Being able to access/copy the allocator has value in some object construction idioms I use and this was missing. Adding an additional `set_allocator()` method would be pretty easy, and I can put that together if we feel there's a need.