### PR TITLE
Update test source for C++20 aggregate change

### DIFF
--- a/test/source/TestOptional.cpp
+++ b/test/source/TestOptional.cpp
@@ -542,11 +542,6 @@ int TestOptional()
 			struct local
 			{
 				eastl::unique_ptr<int> ptr;
-
-				local(const local&) = delete;
-				local(local&&) = default;
-				local& operator=(const local&) = delete;
-				local& operator=(local&&) = default;
 			};
 
 			eastl::optional<local> o1 = local{eastl::make_unique<int>(42)};


### PR DESCRIPTION
Provides the fix suggested in #238 

The C++20 draft standard changes the definition of aggregate to exclude types which have any user-declared constructor. In this test source, `local` is no longer an aggregate and thus cannot be aggregate-initialized. However, the defaulted and deleted ctors in this struct are redundant, because the `unique_ptr` member already defaults and deletes the same constructors--so, by default the copy ctor is deleted and the move ctor is defaulted.