### PR TITLE
eastl: add support for Linux AArch64

### DIFF
--- a/test/packages/EABase/include/Common/EABase/config/eaplatform.h
+++ b/test/packages/EABase/include/Common/EABase/config/eaplatform.h
@@ -384,6 +384,9 @@
 		#define EA_ABI_ARM_LINUX 1
 		#define EA_PROCESSOR_ARM32 1
 		#define EA_PLATFORM_DESCRIPTION "Linux on ARM 6/7 32-bits"
+	#elif defined(__aarch64__) || defined(__AARCH64)
+		#define EA_PROCESSOR_ARM64 1
+		#define EA_PLATFORM_DESCRIPTION "Linux on ARM64"
 	#elif defined(__x86_64__)
 		#define EA_PROCESSOR_X86_64 1
 		#define EA_SYSTEM_LITTLE_ENDIAN 1


### PR DESCRIPTION
Borrowed definitions from Android/iPhone ARM64.

Signed-off-by: Maury Anderson <maury.anderson@rockwellcollins.com>
Signed-off-by: Matthew Weber <matthew.weber@rockwellcollins.com>