### PR TITLE
Fix compilation error on CharStrlen not being a constexpr

### DIFF
--- a/include/EASTL/internal/char_traits.h
+++ b/include/EASTL/internal/char_traits.h
@@ -232,16 +232,16 @@ namespace eastl
 		}
 	#endif
 
-	inline size_t CharStrlen(const char8_t* p)
+	inline constexpr size_t CharStrlen(const char8_t* p)
 	{
-		#if defined(_MSC_VER) || defined(__GNUC__) 
-			return strlen(p);
-		#else
+//		#if defined(_MSC_VER) || defined(__GNUC__) 
+//			return strlen(p);
+//		#else
 			const char8_t* pCurrent = p;
 			while(*pCurrent)
 				++pCurrent;
 			return (size_t)(pCurrent - p);
-		#endif
+//		#endif
 	}
 
 	inline size_t CharStrlen(const char16_t* p)


### PR DESCRIPTION
Fix compilation error on CharStrlen not being a constexpr when creating an array of constexpr eastl::strings -- like in: static constexpr std::array<eastl::string_view, 8192000> eastlStringKeys = {"key1", "key2", ...};

-- Please, treat this PR just as a mean for me to point out the issue and a possible fix. I understand that the real solution will probably involve a redesign of CharStrlen, since we don't want to always drop using strlen.
-- I tested on Linux only.