### PR TITLE
Constexpr String View

### DIFF
--- a/include/EASTL/internal/char_traits.h
+++ b/include/EASTL/internal/char_traits.h
@@ -232,19 +232,15 @@ namespace eastl
 		}
 	#endif
 
-	inline size_t CharStrlen(const char8_t* p)
+	inline EA_CONSTEXPR size_t CharStrlen(const char8_t* p)
 	{
-		#if defined(_MSC_VER) || defined(__GNUC__) 
-			return strlen(p);
-		#else
-			const char8_t* pCurrent = p;
-			while(*pCurrent)
-				++pCurrent;
-			return (size_t)(pCurrent - p);
-		#endif
+		const char8_t* pCurrent = p;
+		while(*pCurrent)
+			++pCurrent;
+		return (size_t)(pCurrent - p);
 	}
 
-	inline size_t CharStrlen(const char16_t* p)
+	inline EA_CONSTEXPR size_t CharStrlen(const char16_t* p)
 	{
 		const char16_t* pCurrent = p;
 		while(*pCurrent)
@@ -252,7 +248,7 @@ namespace eastl
 		return (size_t)(pCurrent - p);
 	}
 
-	inline size_t CharStrlen(const char32_t* p)
+	inline EA_CONSTEXPR size_t CharStrlen(const char32_t* p)
 	{
 		const char32_t* pCurrent = p;
 		while(*pCurrent)
@@ -261,7 +257,7 @@ namespace eastl
 	}
 
 	#if defined(EA_WCHAR_UNIQUE) && EA_WCHAR_UNIQUE
-		inline size_t CharStrlen(const wchar_t* p)
+		inline EA_CONSTEXPR size_t CharStrlen(const wchar_t* p)
 		{
 			const wchar_t* pCurrent = p;
 			while(*pCurrent)

--- a/include/EASTL/internal/char_traits.h
+++ b/include/EASTL/internal/char_traits.h
@@ -232,7 +232,7 @@ namespace eastl
 		}
 	#endif
 
-	inline EA_CONSTEXPR size_t CharStrlen(const char8_t* p)
+	inline EA_CPP14_CONSTEXPR size_t CharStrlen(const char8_t* p)
 	{
 		const char8_t* pCurrent = p;
 		while(*pCurrent)
@@ -240,7 +240,7 @@ namespace eastl
 		return (size_t)(pCurrent - p);
 	}
 
-	inline EA_CONSTEXPR size_t CharStrlen(const char16_t* p)
+	inline EA_CPP14_CONSTEXPR size_t CharStrlen(const char16_t* p)
 	{
 		const char16_t* pCurrent = p;
 		while(*pCurrent)
@@ -248,7 +248,7 @@ namespace eastl
 		return (size_t)(pCurrent - p);
 	}
 
-	inline EA_CONSTEXPR size_t CharStrlen(const char32_t* p)
+	inline EA_CPP14_CONSTEXPR size_t CharStrlen(const char32_t* p)
 	{
 		const char32_t* pCurrent = p;
 		while(*pCurrent)
@@ -257,7 +257,7 @@ namespace eastl
 	}
 
 	#if defined(EA_WCHAR_UNIQUE) && EA_WCHAR_UNIQUE
-		inline EA_CONSTEXPR size_t CharStrlen(const wchar_t* p)
+		inline EA_CPP14_CONSTEXPR size_t CharStrlen(const wchar_t* p)
 		{
 			const wchar_t* pCurrent = p;
 			while(*pCurrent)


### PR DESCRIPTION
Using eastl::string_view in a constexpr context causes a compile error, this fixes #250 