### PR TITLE
Fix unused parameter warning in monostate hash specialization

### DIFF
--- a/include/EASTL/variant.h
+++ b/include/EASTL/variant.h
@@ -159,9 +159,9 @@ namespace eastl
 	// 20.7.11, hash support
 	template <class T> struct hash;
 	template <> struct hash<monostate>
-		{ size_t operator()(monostate val) const { return static_cast<size_t>(-0x42); } };
+		{ size_t operator()(monostate) const { return static_cast<size_t>(-0x42); } };
 
-	
+
 	///////////////////////////////////////////////////////////////////////////
 	// variant_storage
 	// 


### PR DESCRIPTION
The `hash` specialization for monostate had a named parameter (`val`) that wasn't being used by the implementation, and so triggered a C4100 warning under MSVC when compiling with warning level 4 (/W4).

As it's totally unused I just removed the parameter name from the signature rather than using `EA_UNUSED`, for consistency with other PRs (eg. #159).