### PR TITLE
Fix UB causing crashes with some compilers.

### DIFF
--- a/include/EASTL/internal/copy_help.h
+++ b/include/EASTL/internal/copy_help.h
@@ -112,6 +112,9 @@ namespace eastl
 		template <typename T>
 		static T* move_or_copy(const T* first, const T* last, T* result)
 		{
+			if (EASTL_UNLIKELY(first == last))
+				return result;
+
 			// We could use memcpy here if there's no range overlap, but memcpy is rarely much faster than memmove.
 			return (T*)memmove(result, first, (size_t)((uintptr_t)last - (uintptr_t)first)) + (last - first);
 		}


### PR DESCRIPTION
It's not allowed to call memmove with null pointers even if the size is 0.
In vector::DoInsertValueEnd memmove is called via eastl::uninitialized_move_ptr_if_noexcept unconditionally even for null pointers (when vector is empty).
Therefore, further checks for p in vector::DoFree and allocator::deallocate get optimized away that leads to crashes.

_Maybe_ it's related to this:
https://github.com/electronicarts/EASTL/blob/master/CMakeLists.txt#L58