### PR TITLE
Add MSVC-specific initializer_list constructor

### DIFF
--- a/include/EASTL/initializer_list.h
+++ b/include/EASTL/initializer_list.h
@@ -56,6 +56,13 @@
 			initializer_list() EA_NOEXCEPT  // EA_NOEXCEPT requires a recent version of EABase.  
 			  : mpArray(NULL), mArraySize(0) { }
 
+#if defined(EA_COMPILER_MSVC)
+			// MSVC generates constructor calls with two pointers instead of one pointer + size. The constructor is public.
+			// https://docs.microsoft.com/en-us/cpp/standard-library/initializer-list-class#initializer_list
+			initializer_list(const_iterator pFirst, const_iterator pLast) EA_NOEXCEPT
+			  : mpArray(pFirst), mArraySize(pLast - pFirst) { }
+#endif
+
 			size_type      size()  const EA_NOEXCEPT { return mArraySize; }
 			const_iterator begin() const EA_NOEXCEPT { return mpArray; }            // Must be const_iterator, as initializer_list (and its mpArray) is an immutable temp object.
 			const_iterator end()   const EA_NOEXCEPT { return mpArray + mArraySize; }


### PR DESCRIPTION
MSVC will not use the iterator + size constructor, so a
custom one has to be added.

Please drop me a note if you need the CLA signed or if this can be considered a trivial (non-copyrightable) change.