### PR TITLE
Fix memory leak in string_hash_map::insert_or_assign

### DIFF
--- a/include/EASTL/string_hash_map.h
+++ b/include/EASTL/string_hash_map.h
@@ -125,7 +125,12 @@ template<typename T, typename Hash, typename Predicate, typename Allocator>
 eastl::pair<typename string_hash_map<T, Hash, Predicate, Allocator>::iterator, bool>
 string_hash_map<T, Hash, Predicate, Allocator>::insert_or_assign(const char* key, const T& value)
 {
-	return base::base_type::insert_or_assign(strduplicate(key), value);
+	iterator i = base::base_type::find(key);
+	if (i != base::base_type::end()) {
+		return base::base_type::insert_or_assign(i->first, value);
+	} else {
+		return base::base_type::insert_or_assign(strduplicate(key), value);
+	}
 }
 
 template<typename T, typename Hash, typename Predicate, typename Allocator>

--- a/test/source/TestStringHashMap.cpp
+++ b/test/source/TestStringHashMap.cpp
@@ -4,6 +4,7 @@
 
 
 #include "EASTLTest.h"
+#include <EASTL/fixed_allocator.h>
 #include <EASTL/string_hash_map.h>
 #include <EAStdC/EAString.h>
 
@@ -277,6 +278,31 @@ int TestStringHashMap()
 			EATEST_VERIFY(m["hello"].mX == 43);
 
 			EATEST_VERIFY(m.size() == 1);
+		}
+
+		{
+			typedef string_hash_map<TestObject, hash<const char*>, str_equal_to<const char*>, fixed_allocator> fixed_string_hash_map;
+			typedef fixed_string_hash_map::node_type fixed_string_hash_map_node;
+			fixed_string_hash_map_node buffer[2];
+			fixed_string_hash_map m;
+			m.get_allocator().init(buffer, sizeof(buffer), sizeof(fixed_string_hash_map_node), __alignof(fixed_string_hash_map_node));
+
+			#if EASTL_FIXED_SIZE_TRACKING_ENABLED
+				fixed_allocator& a = m.get_allocator();
+				EATEST_VERIFY((a.mnCurrentSize == a.mnPeakSize) && (a.mnCurrentSize == 0));
+			#endif
+
+			m.insert_or_assign("hello", TestObject(42));
+			EATEST_VERIFY(m["hello"].mX == 42);
+
+			m.insert_or_assign("hello", TestObject(43));
+			EATEST_VERIFY(m["hello"].mX == 43);
+
+			EATEST_VERIFY(m.size() == 1);
+
+			#if EASTL_FIXED_SIZE_TRACKING_ENABLED
+				EATEST_VERIFY((a.mnCurrentSize == a.mnPeakSize) && (a.mnCurrentSize == 3));
+			#endif
 		}
 	}
 

--- a/test/source/TestStringHashMap.cpp
+++ b/test/source/TestStringHashMap.cpp
@@ -285,7 +285,8 @@ int TestStringHashMap()
 			typedef fixed_string_hash_map::node_type fixed_string_hash_map_node;
 			fixed_string_hash_map_node buffer[2];
 			fixed_string_hash_map m;
-			m.get_allocator().init(buffer, sizeof(buffer), sizeof(fixed_string_hash_map_node), __alignof(fixed_string_hash_map_node));
+			const size_t  kAlignmentOfNode = EA_ALIGN_OF(fixed_string_hash_map_node);
+			m.get_allocator().init(buffer, sizeof(buffer), sizeof(fixed_string_hash_map_node), kAlignmentOfNode);
 
 			#if EASTL_FIXED_SIZE_TRACKING_ENABLED
 				fixed_allocator& a = m.get_allocator();

--- a/test/source/TestStringHashMap.cpp
+++ b/test/source/TestStringHashMap.cpp
@@ -301,7 +301,9 @@ int TestStringHashMap()
 			EATEST_VERIFY(m.size() == 1);
 
 			#if EASTL_FIXED_SIZE_TRACKING_ENABLED
-				EATEST_VERIFY((a.mnCurrentSize == a.mnPeakSize) && (a.mnCurrentSize == 3));
+				// 1 key + 2 TestObjects = 3 objects
+				const int expectedSize = 3;
+				EATEST_VERIFY((a.mnCurrentSize == a.mnPeakSize) && (a.mnCurrentSize == expectedSize));
 			#endif
 		}
 	}

--- a/test/source/main.cpp
+++ b/test/source/main.cpp
@@ -92,7 +92,7 @@ int EAMain(int argc, char* argv[])
 	testSuite.AddTest("Extra",					TestExtra);
 	testSuite.AddTest("FixedFunction",			TestFixedFunction);
 	testSuite.AddTest("FixedHash",				TestFixedHash);
-	testSuite.AddTest("FixedHash",				TestStringHashMap);
+	testSuite.AddTest("StringHashMap",			TestStringHashMap);
 	testSuite.AddTest("FixedList",				TestFixedList);
 	testSuite.AddTest("FixedMap",				TestFixedMap);
 	testSuite.AddTest("FixedSList",				TestFixedSList);


### PR DESCRIPTION
Previous implementation always duplicated the key
(even if a previous key already existed).

A leak occurred because the clear was not aware of the
previous key that was discared by the newly duplicated key.

This solution only duplicates a new key if necessary.