### PR TITLE
Add stable_partition algorithm with unit tests

### DIFF
--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -724,7 +724,7 @@ namespace eastl
 
 		typedef typename iterator_traits<ForwardIterator>::value_type value_type;
 
-		auto const requested_size = eastl::distance(first, last);
+		const auto requested_size = eastl::distance(first, last);
 
 		auto allocator = *get_default_allocator(0);
 		value_type* const buffer =

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -709,7 +709,55 @@ namespace eastl
 		return begin;
 	}
 
+	/// stable_partition
+	///
+	/// Performs the same function as @p partition() with the additional
+	/// guarantee that the relative ordering of elements in each group is
+	/// preserved.
+	template <typename ForwardIterator, typename Predicate>
+	ForwardIterator stable_partition(ForwardIterator first, ForwardIterator last, Predicate pred)
+	{
+		first = eastl::find_if_not(first, last, pred);
 
+		if (first == last)
+			return first;
+
+		typedef typename iterator_traits<ForwardIterator>::value_type value_type;
+
+		auto const requested_size = eastl::distance(first, last);
+
+		auto allocator = *get_default_allocator(0);
+		value_type* const buffer =
+		    (value_type*)allocate_memory(allocator, requested_size * sizeof(value_type), EASTL_ALIGN_OF(value_type), 0);
+		eastl::uninitialized_fill(buffer, buffer + requested_size, value_type());
+
+		ForwardIterator result1 = first;
+		value_type* result2 = buffer;
+
+		*result2 = eastl::move(*first);
+		++result2;
+		++first;
+		for (; first != last; ++first)
+		{
+			if (pred(*first))
+			{
+				*result1 = eastl::move(*first);
+				++result1;
+			}
+			else
+			{
+				*result2 = eastl::move(*first);
+				++result2;
+			}
+		}
+
+		eastl::copy(buffer, result2, result1);
+
+		eastl::destruct(buffer, buffer + requested_size);
+		EASTLFree(allocator, buffer, requested_size * sizeof(value_type));
+		
+		return result1;
+	}
 
 	/////////////////////////////////////////////////////////////////////
 	// quick_sort

--- a/test/source/TestSort.cpp
+++ b/test/source/TestSort.cpp
@@ -17,6 +17,7 @@
 #include <EASTL/sort.h>
 #include <EASTL/bonus/sort_extra.h>
 #include <EASTL/vector.h>
+#include <EASTL/list.h>
 #include <EASTL/deque.h>
 #include <EASTL/algorithm.h>
 #include <EASTL/allocator.h>
@@ -821,6 +822,40 @@ int TestSort()
 		EATEST_VERIFY(is_sorted(floatArray.begin(), floatArray.end(), SafeFloatCompare()));
 	}
 
+	auto test_stable_sort = [&](auto testArray, size_t count)
+	{
+		for (size_t i = 0; i < count; i++)
+			testArray.push_back((uint16_t)rng.Rand());
+
+		vector<uint16_t> evenArray;
+		vector<uint16_t> oddArray;
+
+		eastl::copy_if(testArray.begin(), testArray.end(), eastl::back_inserter(evenArray), 
+		    [](uint16_t val) { return (val % 2) == 0; });
+		eastl::copy_if(testArray.begin(), testArray.end(), eastl::back_inserter(oddArray),
+		    [](uint16_t val) { return (val % 2) != 0; });
+
+		auto const boundary = eastl::stable_partition(testArray.begin(), testArray.end(), [](uint16_t val) { return val % 2 == 0; });
+		auto const evenCount = eastl::distance(testArray.begin(), boundary);
+		auto const oddCount = eastl::distance(boundary, testArray.end());
+		auto const evenExpectedCount = (intptr_t)evenArray.size();
+		auto const oddExpectedCount = (intptr_t)oddArray.size();
+		EATEST_VERIFY(evenCount == evenExpectedCount);
+		EATEST_VERIFY(oddCount == oddExpectedCount);
+		EATEST_VERIFY(eastl::equal(testArray.begin(), boundary, evenArray.begin()));
+		EATEST_VERIFY(eastl::equal(boundary, testArray.end(), oddArray.begin()));
+	};
+
+	// Test stable_partition
+	test_stable_sort(vector<uint16_t>(), 1000);
+	// Test stable_partition on empty container
+	test_stable_sort(vector<uint16_t>(), 0);
+	// Test stable_partition on container of one element
+	test_stable_sort(vector<uint16_t>(), 1);
+	// Test stable_partition on container of two element
+	test_stable_sort(vector<uint16_t>(), 2);
+	// Test stable_partition on bidirectional iterator (not random access)
+	test_stable_sort(list<uint16_t>(), 0);
 
 	#if 0 // Disabled because it takes a long time and thus far seems to show no bug in quick_sort.
 	{


### PR DESCRIPTION
Hi!

This is my first PR to EASTL so hello everybody!

I would like to add the `stable_partition` algo in the EASTL.
I added the algo in *Sort.h* and the UT in *TestSort.h*
Let me know if there is some way to launch the unit test on a CI system. I can't test the code on all compiler/OS.

The `stable_partition` is a bit tricky because it is generally done in a way it can be executed even if there is not enough memory.
The version of gcc and msvc, use `get_temporary_buffer` to get the buffer. In the `std`, this function can return **less** memory than requested. That mean that the algo need to handle the case of a buffer smaller than the range to process. This make the algo pretty complicated, but resilient to low memory situation.
**But** I see that in EASTL the `get_temporary_buffer` always return a buffer with the requested amount of memory (Let me know if I am wrong). So I decided to do not handle the case of a buffer smaller than the range. This make the algo simpler but less robust in case of memory full. 
Let me know if you are ok with that. I can still change it.