### PR TITLE
Fixed conv ctor and assign op compilation error

### DIFF
--- a/include/EASTL/variant.h
+++ b/include/EASTL/variant.h
@@ -712,7 +712,7 @@ namespace eastl
 			static_assert((meta::type_count_v<T_j, Types...> == 1), "function overload is not unique - duplicate types in type list");
 
 			mIndex = static_cast<variant_index_t>(I);
-			mStorage.template set_as<T_j>(eastl::forward<T_j>(t));
+			mStorage.template set_as<T_j>(eastl::forward<T>(t));
 		}
 
 
@@ -857,7 +857,7 @@ namespace eastl
 				mStorage.destroy();
 
 			mIndex = static_cast<variant_index_t>(I);
-			mStorage.template set_as<T_j>(eastl::forward<T_j>(t));
+			mStorage.template set_as<T_j>(eastl::forward<T>(t));
 			return *this;
 		}
 

--- a/test/source/TestMap.cpp
+++ b/test/source/TestMap.cpp
@@ -196,6 +196,17 @@ int TestMap()
 //        EATEST_VERIFY(p1 == p2); 
 //    }
 
+    { //Test empty base-class optimization
+        struct UnemptyLess : eastl::less<int> {
+            int foo;
+        };
+
+        typedef eastl::map<int, int, eastl::less<int>> VM1;
+        typedef eastl::map<int, int, UnemptyLess> VM2;
+
+        EATEST_VERIFY(sizeof(VM1) < sizeof(VM2));
+    }
+
 
 	return nErrorCount;
 }

--- a/test/source/TestMap.cpp
+++ b/test/source/TestMap.cpp
@@ -196,17 +196,6 @@ int TestMap()
 //        EATEST_VERIFY(p1 == p2); 
 //    }
 
-    { //Test empty base-class optimization
-        struct UnemptyLess : eastl::less<int> {
-            int foo;
-        };
-
-        typedef eastl::map<int, int, eastl::less<int>> VM1;
-        typedef eastl::map<int, int, UnemptyLess> VM2;
-
-        EATEST_VERIFY(sizeof(VM1) < sizeof(VM2));
-    }
-
 
 	return nErrorCount;
 }

--- a/test/source/TestVariant.cpp
+++ b/test/source/TestVariant.cpp
@@ -776,7 +776,7 @@ int TestVariantMoveOnly()
 
 
 //compilation test related to PR #315: converting constructor and assignment operator compilation error
-void add(const double e) { eastl::variant<double> v{e}; }
+void TestCompilation(const double e) { eastl::variant<double> v{e}; }
 
 
 

--- a/test/source/TestVariant.cpp
+++ b/test/source/TestVariant.cpp
@@ -775,6 +775,10 @@ int TestVariantMoveOnly()
 }
 
 
+//compilation test related to PR #315: converting constructor and assignment operator compilation error
+void add(const double e) { eastl::variant<double> v{e}; }
+
+
 
 int TestVariant()
 {


### PR DESCRIPTION
The error message is: forward: none of the 2 overloads could convert all the argument types.
Code to reproduce:
void add(const double e) {variant<double> v{e};}