### PR TITLE
"Fix" MinGW-w64 string test failure.

### DIFF
--- a/test/source/TestString.cpp
+++ b/test/source/TestString.cpp
@@ -73,7 +73,7 @@ int TestString()
 		VERIFY(eastl::to_string(42ull) == "42");
 		VERIFY(eastl::to_string(42.f)  == "42.000000");
 		VERIFY(eastl::to_string(42.0)  == "42.000000");
-	#ifndef EA_COMPILER_GNUC
+	#if !defined(EA_COMPILER_GNUC) && !defined(EA_PLATFORM_MINGW)
 		// todo:  long double sprintf functionality is unrealiable on unix-gcc, requires further debugging.  
 		VERIFY(eastl::to_string(42.0l) == "42.000000");
 	#endif
@@ -89,7 +89,7 @@ int TestString()
 		VERIFY(eastl::to_wstring(42ull) == L"42");
 		VERIFY(eastl::to_wstring(42.f)  == L"42.000000");
 		VERIFY(eastl::to_wstring(42.0)  == L"42.000000");
-	#ifndef EA_COMPILER_GNUC
+	#if !defined(EA_COMPILER_GNUC) && !defined(EA_PLATFORM_MINGW)
 		// todo:  long double sprintf functionality is unrealiable on unix-gcc, requires further debugging.  
 		VERIFY(eastl::to_wstring(42.0l) == L"42.000000");
 	#endif


### PR DESCRIPTION
Ignore the long double sprintf test on MinGW-w64 too, this test fails with both clang and gcc.