### PR TITLE
fix clang never using constexpr

### DIFF
--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -143,18 +143,20 @@
 // http://en.wikipedia.org/wiki/C%2B%2B14#Relaxed_constexpr_restrictions
 //
 #if !defined(EA_CPP14_CONSTEXPR)
-
 	#if defined(EA_COMPILER_MSVC_2015)
-		#define EA_CPP14_CONSTEXPR  // not supported
-		#define EA_NO_CPP14_CONSTEXPR 
-	#elif defined(__GNUC__) && (EA_COMPILER_VERSION < 9000)   // Before GCC 9.0
-		#define EA_CPP14_CONSTEXPR  // not supported
-		#define EA_NO_CPP14_CONSTEXPR 
+		#define EA_CPP14_CONSTEXPR // not supported
+		#define EA_NO_CPP14_CONSTEXPR
+	#elif defined(EA_COMPILER_GNUC) && (EA_COMPILER_VERSION < 9000)     // Before GCC 9.0
+		#define EA_CPP14_CONSTEXPR                                      // not supported
+		#define EA_NO_CPP14_CONSTEXPR
+	#elif defined(EA_COMPILER_CLANG) && (EA_COMPILER_VERSION < 500)     // Before clang5
+		#define EA_CPP14_CONSTEXPR                                      // not supported
+		#define EA_NO_CPP14_CONSTEXPR
 	#elif defined(EA_COMPILER_CPP14_ENABLED)
 		#define EA_CPP14_CONSTEXPR constexpr
 	#else
-		#define EA_CPP14_CONSTEXPR  // not supported
-		#define EA_NO_CPP14_CONSTEXPR 
+		#define EA_CPP14_CONSTEXPR // not supported
+		#define EA_NO_CPP14_CONSTEXPR
 	#endif
 #endif
 


### PR DESCRIPTION
I opened an issue yesterday about gcc 9.2 failed to compile some `constexpr` code in here. https://github.com/electronicarts/EASTL/issues/325

I managed to compile it using clang-9 and investigated into this issue. Unluckily, I have no clue why gcc-9 failed but find out there is a bug in here causing clang will never use `constexpr`.

https://github.com/electronicarts/EASTL/blob/1030ad17b2ca3c74fef36df2e4e490817e81b2cf/include/EASTL/internal/config.h#L150

where the `EA_COMPILER_VERSION` is here 

https://github.com/electronicarts/EABase/blob/d62990dc0a11e0cbc483580d7617ce95ec7a123a/include/Common/EABase/config/eacompiler.h#L341
```
		#define EA_COMPILER_VERSION (__clang_major__ * 100 + __clang_minor__)
```

Since clang will define `__GNUC__` and the **EA_COMPILER_VERSION** will be caculated as *_major_ * 100 + _minor_*, a clang-9.0.0 compiler will get *900* as its version value and thus never passing the resolving.

Accroding to [C++ Support in Clang](https://clang.llvm.org/cxx_status.html), in clang-5 it has implement all features in C++17 and clang-3.4 in C++14. 

Tested on clang-5 and clang-9. 
**BTW,** I think the gcc 9 still have bug in constexpr so the resolving  about gcc 9 here is not proper.