### PR TITLE
Avoid non-public header thr/xtimec.h on Win32

### DIFF
--- a/include/EASTL/chrono.h
+++ b/include/EASTL/chrono.h
@@ -43,6 +43,10 @@
 	#endif
 	EA_RESTORE_ALL_VC_WARNINGS()
 	#pragma warning(pop)
+#endif
+
+#if defined(EA_PLATFORM_MICROSOFT) && !defined(EA_PLATFORM_MINGW)
+	// Nothing to do
 #elif defined(EA_PLATFORM_SONY)
 	#include <Dinkum/threads/xtimec.h>
 	#include <kernel.h>

--- a/include/EASTL/chrono.h
+++ b/include/EASTL/chrono.h
@@ -43,10 +43,6 @@
 	#endif
 	EA_RESTORE_ALL_VC_WARNINGS()
 	#pragma warning(pop)
-#endif
-
-#if defined(EA_PLATFORM_MICROSOFT) && !defined(EA_PLATFORM_MINGW)
-	#include <thr/xtimec.h>
 #elif defined(EA_PLATFORM_SONY)
 	#include <Dinkum/threads/xtimec.h>
 	#include <kernel.h>


### PR DESCRIPTION
...which doesn't seem to be used in any case.

Note that the name and location of this internal header are subject to change without notice, as happened in the Visual Studio 2019 version 16.4 release. *Not* including the header seems to avoid the problem quite nicely ;)