### PR TITLE
Fix move flavour of vector::DoAssign[FromIterator]

### DIFF
--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -322,7 +322,9 @@ namespace eastl
 		// (iterator categories). This is because in these cases there is an optimized
 		// implementation that can be had for some cases relative to others. Functions
 		// which aren't referenced are neither compiled nor linked into the application.
-		struct should_copy_tag{}; struct should_move_tag : public should_copy_tag{};
+		template <bool bMove> struct should_move_or_copy_tag{};
+		using should_copy_tag = should_move_or_copy_tag<false>;
+		using should_move_tag = should_move_or_copy_tag<true>;
 
 		template <typename ForwardIterator> // Allocates a pointer of array count n and copy-constructs it with [first,last).
 		pointer DoRealloc(size_type n, ForwardIterator first, ForwardIterator last, should_copy_tag);
@@ -1513,7 +1515,7 @@ namespace eastl
 
 		if(n > size_type(internalCapacityPtr() - mpBegin)) // If n > capacity ...
 		{
-			pointer const pNewData = DoRealloc(n, first, last, bMove ? should_move_tag() : should_copy_tag());
+			pointer const pNewData = DoRealloc(n, first, last, should_move_or_copy_tag<bMove>());
 			eastl::destruct(mpBegin, mpEnd);
 			DoFree(mpBegin, (size_type)(internalCapacityPtr() - mpBegin));
 


### PR DESCRIPTION
Expression
>bMove ? should_move_tag() : should_copy_tag()

wasn't working as expected, basically always coalescenig as
should_copy_tag type (*) which resulted always copy-constructed
code-path to be taken instead of move-contructed's one regardless of
bMove value. Which is perfomance degradation

This code-path e.g. used in fixed_vector's move constructor

(*) You can read more about underlying reasons for this behaviour in
https://stackoverflow.com/questions/8535226/return-type-of-ternary-conditional-operator