### PR TITLE
Fix vector::push_back_uninitialized() growth strategy

### DIFF
--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -1058,7 +1058,7 @@ namespace eastl
 	{
 		if(mpEnd == internalCapacityPtr())
 		{
-			const size_type newSize = (size_type)(mpEnd - mpBegin) + 1;
+			const size_type newSize = GetNewCapacity(mpEnd - mpBegin);
 			reserve(newSize);
 		}
  


### PR DESCRIPTION
It was capacity()+1 by some reason, which is extremely slow for certain
usage patterns. Change it's to default GetNewCapacity() which is used
e.g. for normal push_back