### PR TITLE
Using of qualified eastl compare function names

### DIFF
--- a/include/EASTL/bitvector.h
+++ b/include/EASTL/bitvector.h
@@ -1417,7 +1417,7 @@ namespace eastl
 						   const bitvector<Allocator, Element, Container>& b)
 	{
 		// To do: Replace this with a smart compare implementation. This is much slower than it needs to be.
-		return ((a.size() == b.size()) && equal(a.begin(), a.end(), b.begin()));
+		return ((a.size() == b.size()) && eastl::equal(a.begin(), a.end(), b.begin()));
 	}
 
 
@@ -1434,7 +1434,7 @@ namespace eastl
 						  const bitvector<Allocator, Element, Container>& b)
 	{
 		// To do: Replace this with a smart compare implementation. This is much slower than it needs to be.
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
 	}
 
 

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -1479,21 +1479,21 @@ template <typename AllocatorA, typename AllocatorB, typename Indices, typename..
 inline bool operator==(const TupleVecInternal::TupleVecImpl<AllocatorA, Indices, Ts...>& a,
 					   const TupleVecInternal::TupleVecImpl<AllocatorB, Indices, Ts...>& b)
 {
-	return ((a.size() == b.size()) && equal(a.begin(), a.end(), b.begin()));
+	return ((a.size() == b.size()) && eastl::equal(a.begin(), a.end(), b.begin()));
 }
 
 template <typename AllocatorA, typename AllocatorB, typename Indices, typename... Ts>
 inline bool operator!=(const TupleVecInternal::TupleVecImpl<AllocatorA, Indices, Ts...>& a,
 					   const TupleVecInternal::TupleVecImpl<AllocatorB, Indices, Ts...>& b)
 {
-	return ((a.size() != b.size()) || !equal(a.begin(), a.end(), b.begin()));
+	return ((a.size() != b.size()) || !eastl::equal(a.begin(), a.end(), b.begin()));
 }
 
 template <typename AllocatorA, typename AllocatorB, typename Indices, typename... Ts>
 inline bool operator<(const TupleVecInternal::TupleVecImpl<AllocatorA, Indices, Ts...>& a,
 					  const TupleVecInternal::TupleVecImpl<AllocatorB, Indices, Ts...>& b)
 {
-	return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
+	return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
 }
 
 template <typename AllocatorA, typename AllocatorB, typename Indices, typename... Ts>

--- a/include/EASTL/deque.h
+++ b/include/EASTL/deque.h
@@ -2612,19 +2612,19 @@ namespace eastl
 	template <typename T, typename Allocator, unsigned kDequeSubarraySize>
 	inline bool operator==(const deque<T, Allocator, kDequeSubarraySize>& a, const deque<T, Allocator, kDequeSubarraySize>& b)
 	{
-		return ((a.size() == b.size()) && equal(a.begin(), a.end(), b.begin()));
+		return ((a.size() == b.size()) && eastl::equal(a.begin(), a.end(), b.begin()));
 	}
 
 	template <typename T, typename Allocator, unsigned kDequeSubarraySize>
 	inline bool operator!=(const deque<T, Allocator, kDequeSubarraySize>& a, const deque<T, Allocator, kDequeSubarraySize>& b)
 	{
-		return ((a.size() != b.size()) || !equal(a.begin(), a.end(), b.begin()));
+		return ((a.size() != b.size()) || !eastl::equal(a.begin(), a.end(), b.begin()));
 	}
 
 	template <typename T, typename Allocator, unsigned kDequeSubarraySize>
 	inline bool operator<(const deque<T, Allocator, kDequeSubarraySize>& a, const deque<T, Allocator, kDequeSubarraySize>& b)
 	{
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
 	}
 
 	template <typename T, typename Allocator, unsigned kDequeSubarraySize>

--- a/include/EASTL/span.h
+++ b/include/EASTL/span.h
@@ -162,7 +162,7 @@ namespace eastl
 	template <class T, size_t X, class U, size_t Y>
 	EA_CONSTEXPR bool operator<(span<T, X> l, span<U, Y> r)
 	{
-		return lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+		return eastl::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
 	}
 
 	template <class T, size_t X, class U, size_t Y>

--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -1975,21 +1975,21 @@ namespace eastl
 	template <typename T, typename Allocator>
 	inline bool operator==(const vector<T, Allocator>& a, const vector<T, Allocator>& b)
 	{
-		return ((a.size() == b.size()) && equal(a.begin(), a.end(), b.begin()));
+		return ((a.size() == b.size()) && eastl::equal(a.begin(), a.end(), b.begin()));
 	}
 
 
 	template <typename T, typename Allocator>
 	inline bool operator!=(const vector<T, Allocator>& a, const vector<T, Allocator>& b)
 	{
-		return ((a.size() != b.size()) || !equal(a.begin(), a.end(), b.begin()));
+		return ((a.size() != b.size()) || !eastl::equal(a.begin(), a.end(), b.begin()));
 	}
 
 
 	template <typename T, typename Allocator>
 	inline bool operator<(const vector<T, Allocator>& a, const vector<T, Allocator>& b)
 	{
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
 	}
 
 

--- a/include/EASTL/vector_map.h
+++ b/include/EASTL/vector_map.h
@@ -831,7 +831,7 @@ namespace eastl
 	inline bool operator==(const vector_map<Key, T, Compare, Allocator, RandomAccessContainer>& a, 
 						   const vector_map<Key, T, Compare, Allocator, RandomAccessContainer>& b) 
 	{
-		return (a.size() == b.size()) && equal(b.begin(), b.end(), a.begin()); 
+		return (a.size() == b.size()) && eastl::equal(b.begin(), b.end(), a.begin()); 
 	}
 
 
@@ -839,7 +839,7 @@ namespace eastl
 	inline bool operator<(const vector_map<Key, T, Compare, Allocator, RandomAccessContainer>& a,
 						  const vector_map<Key, T, Compare, Allocator, RandomAccessContainer>& b)
 	{
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
 	}
 
 

--- a/include/EASTL/vector_multimap.h
+++ b/include/EASTL/vector_multimap.h
@@ -761,7 +761,7 @@ namespace eastl
 	inline bool operator==(const vector_multimap<K, T, C, A, RAC>& a, 
 						   const vector_multimap<K, T, C, A, RAC>& b) 
 	{
-		return (a.size() == b.size()) && equal(b.begin(), b.end(), a.begin());
+		return (a.size() == b.size()) && eastl::equal(b.begin(), b.end(), a.begin());
 	}
 
 
@@ -769,7 +769,7 @@ namespace eastl
 	inline bool operator<(const vector_multimap<K, T, C, A, RAC>& a,
 						  const vector_multimap<K, T, C, A, RAC>& b)
 	{
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
 	}
 
 

--- a/include/EASTL/vector_multiset.h
+++ b/include/EASTL/vector_multiset.h
@@ -693,7 +693,7 @@ namespace eastl
 	inline bool operator==(const vector_multiset<Key, Compare, Allocator, RandomAccessContainer>& a, 
 						   const vector_multiset<Key, Compare, Allocator, RandomAccessContainer>& b) 
 	{
-		return (a.size() == b.size()) && equal(b.begin(), b.end(), a.begin());
+		return (a.size() == b.size()) && eastl::equal(b.begin(), b.end(), a.begin());
 	}
 
 
@@ -701,7 +701,7 @@ namespace eastl
 	inline bool operator<(const vector_multiset<Key, Compare, Allocator, RandomAccessContainer>& a,
 						  const vector_multiset<Key, Compare, Allocator, RandomAccessContainer>& b)
 	{
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
 	}
 
 

--- a/include/EASTL/vector_set.h
+++ b/include/EASTL/vector_set.h
@@ -731,7 +731,7 @@ namespace eastl
 	inline bool operator==(const vector_set<Key, Compare, Allocator, RandomAccessContainer>& a, 
 						   const vector_set<Key, Compare, Allocator, RandomAccessContainer>& b) 
 	{
-		return (a.size() == b.size()) && equal(b.begin(), b.end(), a.begin());
+		return (a.size() == b.size()) && eastl::equal(b.begin(), b.end(), a.begin());
 	}
 
 
@@ -739,7 +739,7 @@ namespace eastl
 	inline bool operator<(const vector_set<Key, Compare, Allocator, RandomAccessContainer>& a,
 						  const vector_set<Key, Compare, Allocator, RandomAccessContainer>& b)
 	{
-		return lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
+		return eastl::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), a.value_comp());
 	}
 
 


### PR DESCRIPTION
Fixing of compilation error when some of `eastl` containers used with `std` types. Reason: ambiguity of `equal()` and `lexicographical_compare()` functions call in overloaded compare operators, which conflicts with its `std` counterparts. So, you can't compare `eastl::vector<std::string>` using `operators==()`, but compare of `eastl::array<std::string>` works fine, because latter use qualified names for its compare operators.

This PR just unifies using of compare functions across all `eastl` containers. So, all unqualified calls to `equal()` and `lexicographical_compare()` functions replaced with quailified ones.

I'm not sure that's a good idea to write tests which can't be compiled in the pre-PR version, so I skipped this part.

Tested on VS 2017 and GCC 7.4