### PR TITLE
Fix string_view::find_first_of buffer overflow bug

### DIFF
--- a/include/EASTL/string_view.h
+++ b/include/EASTL/string_view.h
@@ -290,7 +290,7 @@ namespace eastl
 
 		EA_CONSTEXPR size_type find_first_of(basic_string_view sw, size_type pos = 0) const EA_NOEXCEPT
 		{
-			return find_first_of(sw.mpBegin, pos, mnCount);
+			return find_first_of(sw.mpBegin, pos, sw.mnCount);
 		}
 
 		EA_CONSTEXPR size_type find_first_of(T c, size_type pos = 0) const EA_NOEXCEPT { return find(c, pos); }

--- a/test/source/TestStringView.inl
+++ b/test/source/TestStringView.inl
@@ -403,6 +403,7 @@ int TEST_STRING_NAME()
 			VERIFY(str.find_first_of(LITERAL("eeef"), 1, 4) == 18);
 			VERIFY(str.find_first_of(LITERAL('g')) == 26);
 			VERIFY(str.find_first_of(LITERAL('$')) == StringViewT::npos);
+			VERIFY(str.find_first_of(StringViewT(LITERAL(" a"), 1)) == StringViewT::npos);
 		}
 
 		// EA_CONSTEXPR size_type find_last_of(basic_string_view s, size_type pos = npos) const EA_NOEXCEPT;


### PR DESCRIPTION
The `find_first_of` overload taking `string_view` parameter was passing the size of `this`, instead of the `sw`'s size, which caused incorrect read of source view's memory.
