### PR TITLE
Added span::front(), back(), and subspan()

### DIFF
--- a/include/EASTL/span.h
+++ b/include/EASTL/span.h
@@ -400,7 +400,7 @@ namespace eastl
 	span<T, Extent>::subspan() const
 	{
 		EASTL_ASSERT_MSG(bounds_check(Offset),                                  "undefined behaviour accessing out of bounds");
-		EASTL_ASSERT_MSG(Count == dynamic_extent || Count <= (size() - Offset), "undefined behaviour accessing out of bounds");
+		EASTL_ASSERT_MSG(Count == dynamic_extent || Count <= (size() - Offset), "undefined behaviour exceeding size of span");
 
 		return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
 	}
@@ -410,7 +410,7 @@ namespace eastl
 	span<T, Extent>::subspan(size_t offset, size_t count) const
 	{
 		EASTL_ASSERT_MSG(bounds_check(offset),                                  "undefined behaviour accessing out of bounds");
-		EASTL_ASSERT_MSG(count == dynamic_extent || count <= (size() - offset), "undefined behaviour accessing out of bounds");
+		EASTL_ASSERT_MSG(count == dynamic_extent || count <= (size() - offset), "undefined behaviour exceeding size of span");
 
 		return {data() + offset, count == dynamic_extent ? size() - offset : count};
 	}

--- a/include/EASTL/span.h
+++ b/include/EASTL/span.h
@@ -65,7 +65,9 @@ namespace eastl
 		typedef eastl_size_t                            index_type;
 		typedef ptrdiff_t                               difference_type;
 		typedef T*                                      pointer;
+		typedef const T*                                const_pointer;
 		typedef T&                                      reference;
+		typedef const T&                                const_reference;
 		typedef T*                                      iterator;
 		typedef const T*                                const_iterator;
 		typedef eastl::reverse_iterator<iterator>       reverse_iterator;

--- a/include/EASTL/span.h
+++ b/include/EASTL/span.h
@@ -30,7 +30,9 @@
 
 namespace eastl
 {
-	namespace Internal 
+	static EA_CONSTEXPR size_t dynamic_extent = size_t(-1);
+
+	namespace Internal
 	{
 		// HasSizeAndData
 		// 
@@ -41,9 +43,18 @@ namespace eastl
 
 		template <typename T>
 		struct HasSizeAndData<T, void_t<decltype(eastl::size(eastl::declval<T>())), decltype(eastl::data(eastl::declval<T>()))>> : eastl::true_type {};
-	}
 
-	static EA_CONSTEXPR size_t dynamic_extent = size_t(-1);
+		// SubspanExtent
+		//
+		// Integral constant that calculates the resulting extent of a templated subspan operation.
+		//
+		//   If Count is not dynamic_extent then SubspanExtent::value is Count,
+		//   otherwise, if Extent is not dynamic_extent, SubspanExtent::value is (Extent - Offset),
+		//   otherwise, SubspanExtent::value is dynamic_extent.
+		//
+		template<size_t Extent, size_t Offset, size_t Count>
+		struct SubspanExtent : eastl::integral_constant<size_t, (Count != dynamic_extent ? Count : (Extent != dynamic_extent ? (Extent - Offset) : dynamic_extent))> {};
+	}
 
 	template <typename T, size_t Extent = eastl::dynamic_extent>
 	class span
@@ -105,9 +116,9 @@ namespace eastl
 		EA_CPP14_CONSTEXPR span<element_type, Count> last() const;
 		EA_CPP14_CONSTEXPR span<element_type, dynamic_extent> last(size_t Count) const;
 
-		// template <size_t Offset, size_t Count = dynamic_extent>
-		// EA_CONSTEXPR span<element_type, E [> see below <]> subspan() const;
-		// EA_CONSTEXPR span<element_type, dynamic_extent> subspan(size_t Offset, size_t Count = dynamic_extent) const;
+		template <size_t Offset, size_t Count = dynamic_extent>
+		EA_CONSTEXPR span<element_type, Internal::SubspanExtent<Extent, Offset, Count>::value> subspan() const;
+		EA_CONSTEXPR span<element_type, dynamic_extent> subspan(size_t Offset, size_t Count = dynamic_extent) const;
 
 		// observers
 		EA_CONSTEXPR pointer    data() const EA_NOEXCEPT;
@@ -381,6 +392,27 @@ namespace eastl
 	{
 		EASTL_ASSERT_MSG(bounds_check(sz), "undefined behavior accessing out of bounds");
 		return {data() + size() - sz, static_cast<index_type>(sz)};
+	}
+
+	template <typename T, size_t Extent>
+	template <size_t Offset, size_t Count>
+	EA_CONSTEXPR span<typename span<T, Extent>::element_type, Internal::SubspanExtent<Extent, Offset, Count>::value>
+	span<T, Extent>::subspan() const
+	{
+		EASTL_ASSERT_MSG(bounds_check(Offset),                                  "undefined behaviour accessing out of bounds");
+		EASTL_ASSERT_MSG(Count == dynamic_extent || Count <= (size() - Offset), "undefined behaviour accessing out of bounds");
+
+		return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
+	}
+
+	template <typename T, size_t Extent>
+	EA_CONSTEXPR span<typename span<T, Extent>::element_type, dynamic_extent>
+	span<T, Extent>::subspan(size_t offset, size_t count) const
+	{
+		EASTL_ASSERT_MSG(bounds_check(offset),                                  "undefined behaviour accessing out of bounds");
+		EASTL_ASSERT_MSG(count == dynamic_extent || count <= (size() - offset), "undefined behaviour accessing out of bounds");
+
+		return {data() + offset, count == dynamic_extent ? size() - offset : count};
 	}
 
 	template <typename T, size_t Extent>

--- a/include/EASTL/span.h
+++ b/include/EASTL/span.h
@@ -116,6 +116,8 @@ namespace eastl
 		EA_CONSTEXPR bool       empty() const EA_NOEXCEPT;
 
 		// subscript operators, element access
+		EA_CONSTEXPR reference front() const;
+		EA_CONSTEXPR reference back() const;
 		EA_CONSTEXPR reference operator[](index_type idx) const;
 		EA_CONSTEXPR reference operator()(index_type idx) const;
 
@@ -264,7 +266,23 @@ namespace eastl
 	template <typename T, size_t Extent>
 	EA_CONSTEXPR bool span<T, Extent>::empty() const EA_NOEXCEPT
 	{
-		return size() == 0; 
+		return size() == 0;
+	}
+
+	template <typename T, size_t Extent>
+	EA_CONSTEXPR typename span<T, Extent>::reference span<T, Extent>::front() const
+	{
+		EASTL_ASSERT_MSG(!empty(), "undefined behavior accessing an empty span");
+
+		return mpData[0];
+	}
+
+	template <typename T, size_t Extent>
+	EA_CONSTEXPR typename span<T, Extent>::reference span<T, Extent>::back() const
+	{
+		EASTL_ASSERT_MSG(!empty(), "undefined behavior accessing an empty span");
+
+		return mpData[mnSize - 1];
 	}
 
 	template <typename T, size_t Extent>

--- a/test/source/TestSpan.cpp
+++ b/test/source/TestSpan.cpp
@@ -389,44 +389,58 @@ void TestSpanSubViews(int& nErrorCount)
 		VERIFY(first_span[3] == 9);
 	}
 
-	{ // fixed-extent subspan (full-range)
+	{ // subspan: full range
 		span<int, 10> s =  arr1;
-		auto first_span = s.subspan<0, 10>();
-		VERIFY(first_span.size() == 10);
-		VERIFY(first_span[0] == 0);
-		VERIFY(first_span[1] == 1);
-		VERIFY(first_span[8] == 8);
-		VERIFY(first_span[9] == 9);
+
+		auto fixed_span = s.subspan<0, 10>();
+		VERIFY(fixed_span.size() == 10);
+		VERIFY(fixed_span[0] == 0);
+		VERIFY(fixed_span[1] == 1);
+		VERIFY(fixed_span[8] == 8);
+		VERIFY(fixed_span[9] == 9);
+
+		auto dynamic_span = s.subspan(0, s.size());
+		VERIFY(dynamic_span.size() == 10);
+		VERIFY(dynamic_span[0] == 0);
+		VERIFY(dynamic_span[1] == 1);
+		VERIFY(dynamic_span[8] == 8);
+		VERIFY(dynamic_span[9] == 9);
 	}
 
-	{ // fixed-extent subspan (sub-range)
+	{ // subspan: subrange
 		span<int, 10> s =  arr1;
-		auto first_span = s.subspan<3, 4>();
-		VERIFY(first_span.size() == 4);
-		VERIFY(first_span[0] == 3);
-		VERIFY(first_span[1] == 4);
-		VERIFY(first_span[2] == 5);
-		VERIFY(first_span[3] == 6);
+
+		auto fixed_span = s.subspan<3, 4>();
+		VERIFY(fixed_span.size() == 4);
+		VERIFY(fixed_span[0] == 3);
+		VERIFY(fixed_span[1] == 4);
+		VERIFY(fixed_span[2] == 5);
+		VERIFY(fixed_span[3] == 6);
+
+		auto dynamic_span = s.subspan(3, 4);
+		VERIFY(dynamic_span.size() == 4);
+		VERIFY(dynamic_span[0] == 3);
+		VERIFY(dynamic_span[1] == 4);
+		VERIFY(dynamic_span[2] == 5);
+		VERIFY(dynamic_span[3] == 6);
 	}
 
-	{ // dynamic-extent subspan (full-range)
-		span<int> s =  arr1;
-		auto first_span = s.subspan(0, s.size());
-		VERIFY(first_span.size() == 10);
-		VERIFY(first_span[0] == 0);
-		VERIFY(first_span[1] == 1);
-		VERIFY(first_span[8] == 8);
-		VERIFY(first_span[9] == 9);
-	}
+	{ // subspan: default count
+		span<int, 10> s =  arr1;
 
-	{ // dynamic-extent subspan (sub-range)
-		span<int> s =  arr1;
-		auto first_span = s.subspan(3, 4);
-		VERIFY(first_span.size() == 4);
-		VERIFY(first_span[0] == 3);
-		VERIFY(first_span[1] == 4);
-		VERIFY(first_span[2] == 5);
-		VERIFY(first_span[3] == 6);
+		auto fixed_span = s.subspan<3>();
+		VERIFY(fixed_span.size() == 7);
+		VERIFY(fixed_span[0] == 3);
+		VERIFY(fixed_span[1] == 4);
+		VERIFY(fixed_span[5] == 8);
+		VERIFY(fixed_span[6] == 9);
+
+		auto dynamic_span = s.subspan(3);
+		VERIFY(dynamic_span.size() == 7);
+		VERIFY(dynamic_span[0] == 3);
+		VERIFY(dynamic_span[1] == 4);
+		VERIFY(dynamic_span[5] == 8);
+		VERIFY(dynamic_span[6] == 9);
 	}
 }
 

--- a/test/source/TestSpan.cpp
+++ b/test/source/TestSpan.cpp
@@ -388,6 +388,46 @@ void TestSpanSubViews(int& nErrorCount)
 		VERIFY(first_span[2] == 8);
 		VERIFY(first_span[3] == 9);
 	}
+
+	{ // fixed-extent subspan (full-range)
+		span<int, 10> s =  arr1;
+		auto first_span = s.subspan<0, 10>();
+		VERIFY(first_span.size() == 10);
+		VERIFY(first_span[0] == 0);
+		VERIFY(first_span[1] == 1);
+		VERIFY(first_span[8] == 8);
+		VERIFY(first_span[9] == 9);
+	}
+
+	{ // fixed-extent subspan (sub-range)
+		span<int, 10> s =  arr1;
+		auto first_span = s.subspan<3, 4>();
+		VERIFY(first_span.size() == 4);
+		VERIFY(first_span[0] == 3);
+		VERIFY(first_span[1] == 4);
+		VERIFY(first_span[2] == 5);
+		VERIFY(first_span[3] == 6);
+	}
+
+	{ // dynamic-extent subspan (full-range)
+		span<int> s =  arr1;
+		auto first_span = s.subspan(0, s.size());
+		VERIFY(first_span.size() == 10);
+		VERIFY(first_span[0] == 0);
+		VERIFY(first_span[1] == 1);
+		VERIFY(first_span[8] == 8);
+		VERIFY(first_span[9] == 9);
+	}
+
+	{ // dynamic-extent subspan (sub-range)
+		span<int> s =  arr1;
+		auto first_span = s.subspan(3, 4);
+		VERIFY(first_span.size() == 4);
+		VERIFY(first_span[0] == 3);
+		VERIFY(first_span[1] == 4);
+		VERIFY(first_span[2] == 5);
+		VERIFY(first_span[3] == 6);
+	}
 }
 
 int TestSpan()

--- a/test/source/TestSpan.cpp
+++ b/test/source/TestSpan.cpp
@@ -120,13 +120,16 @@ void TestSpanSizeBytes(int& nErrorCount)
 	}
 }
 
-void TestSpanSubscript(int& nErrorCount)
+void TestSpanElementAccess(int& nErrorCount)
 {
 	using namespace eastl;
 
 	{
 		int arr[5] = {0, 1, 2, 3, 4};
 		span<int> s(arr);
+
+		VERIFY(s.front() == 0);
+		VERIFY(s.back() == 4);
 
 		VERIFY(s[0] == 0);
 		VERIFY(s[1] == 1);
@@ -393,7 +396,7 @@ int TestSpan()
 
 	TestSpanCtor(nErrorCount);
 	TestSpanSizeBytes(nErrorCount);
-	TestSpanSubscript(nErrorCount);
+	TestSpanElementAccess(nErrorCount);
 	TestSpanIterators(nErrorCount);
 	TestSpanCopyAssignment(nErrorCount);
 	TestSpanContainerConversion(nErrorCount);


### PR DESCRIPTION
Implements the missing `span::front()` and `span::back()` element access members, as well as the `span::subspan()` operation.

Each of the new members follows the same implementation rules used by the existing `span` code and will assert if the user would otherwise invoke undefined behaviour:
* `span::front()` and `span::back()` will assert if the span is empty.
* `span::subspan()` will assert if offset or count exceed the bounds of the span.

Tests are included for each member as follows:
* `span::front()` and `span::back()` are tested along with the existing subscript operator case which I've renamed to TestElementAccess; didn't seem worth putting these in a separate test but calling them subscript operators wasn't really accurate.
* `span::subspan()` tests cases where the range of the subspan is equal to the full range of the original span, a subrange, and an offset with the default count parameter (`dynamic_extent`).

Tested successfully under Clang 9 and GCC 9.2.0.