### PR TITLE
Fix missing explicit constructors in span::rbegin/rend()

### DIFF
--- a/include/EASTL/span.h
+++ b/include/EASTL/span.h
@@ -312,13 +312,13 @@ namespace eastl
 	template <typename T, size_t Extent>
 	EA_CONSTEXPR typename span<T, Extent>::reverse_iterator span<T, Extent>::rbegin() const EA_NOEXCEPT
 	{
-		return mpData + mnSize;
+		return reverse_iterator(mpData + mnSize);
 	}
 
 	template <typename T, size_t Extent>
 	EA_CONSTEXPR typename span<T, Extent>::reverse_iterator span<T, Extent>::rend() const EA_NOEXCEPT
 	{
-		return mpData;
+		return reverse_iterator(mpData);
 	}
 
 	template <typename T, size_t Extent>

--- a/test/source/TestSpan.cpp
+++ b/test/source/TestSpan.cpp
@@ -226,7 +226,9 @@ void TestSpanIterators(int& nErrorCount)
 			VERIFY(*p-- == 9);
 		};
 
+		testReverseIteratorBegin(s.rbegin());
 		testReverseIteratorBegin(s.crbegin());
+		testReverseIteratorEnd(s.rend());
 		testReverseIteratorEnd(s.crend());
 	}
 }


### PR DESCRIPTION
Fixes #339. The ticket said that rbegin/rend had tests, but this wasn't the case so I've added them as well.