### PR TITLE
Fix GCC 9.2 constexpr compile errors in array tests

### DIFF
--- a/include/EASTL/iterator.h
+++ b/include/EASTL/iterator.h
@@ -311,11 +311,8 @@ namespace eastl
 		// random_access_iterator operator[] is merely required to return something convertible to reference. 
 		// reverse_iterator operator[] can't necessarily know what to return as the underlying iterator 
 		// operator[] may return something other than reference.
-		// reference operator[](difference_type n) const
-		//     { return mIterator[-n - 1]; }
-
 		EA_CPP14_CONSTEXPR reference operator[](difference_type n) const
-			{ return *(*this + n); }
+			{ return mIterator[-n - 1]; }
 	};
 
 


### PR DESCRIPTION
Attempted fix for the issue noted in #325 with GCC 9.2.0. Compiling the array tests causes GCC to choke on the subscript operator of reverse_iterator inside of a constant expression.

Using the (commented out) `-n - 1` subscript expression seems to work around this. I can't see anything in the repository history for why it was commented out to begin with, so there might be some implication I'm unaware of, but the tests all still pass under GCC 9.2.0 and Clang 9 for myself at least.