### PR TITLE
C++20 char8_t string/string_view support improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ matrix:
         - compiler: clang "release build with clang to trigger MOJI check"
           env: EASTL_CONFIG=Release USE_MOJI_CHECK=yes
           os: linux
-        - compiler: clang # C++20 char8_t support is present in Clang 7+.
-          env: EASTL_CONFIG=Release EASTL_BUILD_CHAR8T_TESTS=ON
-          os: linux
         - compiler: msvc
           env: EASTL_CONFIG=Release CXXFLAGS="/std:c++latest /Zc:char8_t"
           os: windows 
@@ -72,7 +69,7 @@ install:
 before_script:
   - mkdir build_$EASTL_CONFIG
   - cd build_$EASTL_CONFIG
-  - cmake .. -DEASTL_BUILD_BENCHMARK:BOOL=ON -DEASTL_BUILD_TESTS:BOOL=ON -DEASTL_BUILD_CHAR8T_TESTS:BOOL=${EASTL_BUILD_CHAR8T_TESTS}
+  - cmake .. -DEASTL_BUILD_BENCHMARK:BOOL=ON -DEASTL_BUILD_TESTS:BOOL=ON
   - cmake --build . --config $EASTL_CONFIG
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
         - compiler: clang "release build with clang to trigger MOJI check"
           env: EASTL_CONFIG=Release USE_MOJI_CHECK=yes
           os: linux
+        - compiler: clang # C++20 char8_t support is present in Clang 7+.
+          env: EASTL_CONFIG=Release EASTL_BUILD_CHAR8T_TESTS=ON
+          os: linux
         - compiler: msvc
           env: EASTL_CONFIG=Release CXXFLAGS="/std:c++latest /Zc:char8_t"
           os: windows 
@@ -69,7 +72,7 @@ install:
 before_script:
   - mkdir build_$EASTL_CONFIG
   - cd build_$EASTL_CONFIG
-  - cmake .. -DEASTL_BUILD_BENCHMARK:BOOL=ON -DEASTL_BUILD_TESTS:BOOL=ON
+  - cmake .. -DEASTL_BUILD_BENCHMARK:BOOL=ON -DEASTL_BUILD_TESTS:BOOL=ON -DEASTL_BUILD_CHAR8T_TESTS:BOOL=${EASTL_BUILD_CHAR8T_TESTS}
   - cmake --build . --config $EASTL_CONFIG
 
 script:

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -39,6 +39,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_BUILD_TYPE MATCHES "MinSizeR
     message(FATAL_ERROR "FIXME: MinSizeRel on MingW-w64's Clang fails to link.")
 endif()
 
+# The benchmark suite fails to compile if char8_t is enabled, so disable it.
+if (EASTL_NO_CHAR8T_FLAG)
+    add_compile_options(${EASTL_NO_CHAR8T_FLAG})
+endif()
+
 #-------------------------------------------------------------------------------------------
 # Source files
 #-------------------------------------------------------------------------------------------

--- a/include/EASTL/internal/char_traits.h
+++ b/include/EASTL/internal/char_traits.h
@@ -62,6 +62,8 @@ namespace eastl
 	#endif
 
 	#if EA_WCHAR_UNIQUE
+		bool DecodePart(const wchar_t*& pSrc, const wchar_t* pSrcEnd, wchar_t*&  pDest, wchar_t*  pDestEnd);
+
 		bool DecodePart(const wchar_t*& pSrc, const wchar_t* pSrcEnd, char*&     pDest, char*     pDestEnd);
 		bool DecodePart(const wchar_t*& pSrc, const wchar_t* pSrcEnd, char16_t*& pDest, char16_t* pDestEnd);
 		bool DecodePart(const wchar_t*& pSrc, const wchar_t* pSrcEnd, char32_t*& pDest, char32_t* pDestEnd);
@@ -78,6 +80,11 @@ namespace eastl
 
 
 	#if EA_WCHAR_UNIQUE
+		inline bool DecodePart(const wchar_t*& pSrc, const wchar_t* pSrcEnd, wchar_t*& pDest, wchar_t* pDestEnd)
+		{
+			return DecodePart(reinterpret_cast<const char*&>(pSrc), reinterpret_cast<const char*>(pSrcEnd), reinterpret_cast<char*&>(pDest), reinterpret_cast<char*&>(pDestEnd));
+		}
+
 		inline bool DecodePart(const wchar_t*& pSrc, const wchar_t* pSrcEnd, char*& pDest, char* pDestEnd)
 		{
 		#if (EA_WCHAR_SIZE == 2)

--- a/include/EASTL/internal/char_traits.h
+++ b/include/EASTL/internal/char_traits.h
@@ -50,9 +50,15 @@ namespace eastl
 	EASTL_API bool DecodePart(const int*& pSrc, const int* pSrcEnd, char32_t*& pDest, char32_t* pDestEnd);
 
 	#if EA_CHAR8_UNIQUE
+		bool DecodePart(const char8_t*& pSrc, const char8_t* pSrcEnd, char8_t*&  pDest, char8_t*  pDestEnd);
+
 		bool DecodePart(const char8_t*& pSrc, const char8_t* pSrcEnd, char*&     pDest, char*     pDestEnd);
 		bool DecodePart(const char8_t*& pSrc, const char8_t* pSrcEnd, char16_t*& pDest, char16_t* pDestEnd);
 		bool DecodePart(const char8_t*& pSrc, const char8_t* pSrcEnd, char32_t*& pDest, char32_t* pDestEnd);
+
+		bool DecodePart(const char*&     pSrc, const char*     pSrcEnd, char8_t*& pDest, char8_t* pDestEnd);
+		bool DecodePart(const char16_t*& pSrc, const char16_t* pSrcEnd, char8_t*& pDest, char8_t* pDestEnd);
+		bool DecodePart(const char32_t*& pSrc, const char32_t* pSrcEnd, char8_t*& pDest, char8_t* pDestEnd);
 	#endif
 
 	#if EA_WCHAR_UNIQUE
@@ -128,6 +134,11 @@ namespace eastl
 	#endif
 
 	#if EA_CHAR8_UNIQUE
+	    inline bool DecodePart(const char8_t*& pSrc, const char8_t* pSrcEnd, char8_t*& pDest, char8_t* pDestEnd)
+	    {
+		    return DecodePart(reinterpret_cast<const char*&>(pSrc), reinterpret_cast<const char*>(pSrcEnd), reinterpret_cast<char*&>(pDest), reinterpret_cast<char*&>(pDestEnd));
+	    }
+
 	    inline bool DecodePart(const char8_t*& pSrc, const char8_t* pSrcEnd, char*& pDest, char* pDestEnd)
 	    {
 		    return DecodePart(reinterpret_cast<const char*&>(pSrc), reinterpret_cast<const char*>(pSrcEnd), pDest, pDestEnd);
@@ -142,6 +153,21 @@ namespace eastl
 	    {
 		    return DecodePart(reinterpret_cast<const char*&>(pSrc), reinterpret_cast<const char*>(pSrcEnd), pDest, pDestEnd);
 	    }
+
+		inline bool DecodePart(const char*& pSrc, const char* pSrcEnd, char8_t*& pDest, char8_t* pDestEnd)
+		{
+			return DecodePart(pSrc, pSrcEnd, reinterpret_cast<char*&>(pDest), reinterpret_cast<char*&>(pDestEnd));
+		}
+
+		inline bool DecodePart(const char16_t*& pSrc, const char16_t* pSrcEnd, char8_t*& pDest, char8_t* pDestEnd)
+		{
+			return DecodePart(pSrc, pSrcEnd, reinterpret_cast<char*&>(pDest), reinterpret_cast<char*&>(pDestEnd));
+		}
+
+		inline bool DecodePart(const char32_t*& pSrc, const char32_t* pSrcEnd, char8_t*& pDest, char8_t* pDestEnd)
+		{
+			return DecodePart(pSrc, pSrcEnd, reinterpret_cast<char*&>(pDest), reinterpret_cast<char*&>(pDestEnd));
+		}
     #endif
 
 	#if EA_CHAR8_UNIQUE && EA_WCHAR_UNIQUE

--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -3934,6 +3934,21 @@ namespace eastl
 		}
 	};
 
+	#if defined(EA_CHAR8_UNIQUE) && EA_CHAR8_UNIQUE
+		template <>
+		struct hash<string8>
+		{
+			size_t operator()(const string8& x) const
+			{
+				const char8_t* p = (const char8_t*)x.c_str();
+				unsigned int c, result = 2166136261U;
+				while((c = *p++) != 0)
+					result = (result * 16777619) ^ c;
+				return (size_t)result;
+			}
+		};
+	#endif
+
 	template <>
 	struct hash<string16>
 	{
@@ -4051,6 +4066,11 @@ namespace eastl
 				inline u16string operator"" s(const char16_t* str, size_t len) EA_NOEXCEPT { return {str, u16string::size_type(len)}; }
 				inline u32string operator"" s(const char32_t* str, size_t len) EA_NOEXCEPT { return {str, u32string::size_type(len)}; }
 				inline wstring operator"" s(const wchar_t* str, size_t len) EA_NOEXCEPT { return {str, wstring::size_type(len)}; }
+
+				// C++20 char8_t support.
+				#if EA_CHAR8_UNIQUE
+					inline u8string operator"" s(const char8_t* str, size_t len) EA_NOEXCEPT { return {str, u8string::size_type(len)}; }
+				#endif
 		    }
 	    }
 		EA_RESTORE_VC_WARNING()  // warning: 4455

--- a/include/EASTL/string_view.h
+++ b/include/EASTL/string_view.h
@@ -513,7 +513,7 @@ namespace eastl
 	typedef basic_string_view<wchar_t> wstring_view;
 
 	// C++17 string types
-	typedef basic_string_view<char8_t>  u8string_view;  // Actually not a C++17 type, but added for consistency.
+	typedef basic_string_view<char8_t>  u8string_view;  // C++20 feature, but always present for consistency.
 	typedef basic_string_view<char16_t> u16string_view;
 	typedef basic_string_view<char32_t> u32string_view;
 
@@ -540,6 +540,21 @@ namespace eastl
 			return (size_t)result;
 		}
 	};
+
+	#if defined(EA_CHAR8_UNIQUE) && EA_CHAR8_UNIQUE
+		template<> struct hash<u8string_view>
+		{
+			size_t operator()(const u8string_view& x) const
+			{
+				u8string_view::const_iterator p = x.cbegin();
+				u8string_view::const_iterator end = x.cend();
+				uint32_t result = 2166136261U;
+				while (p != end)
+					result = (result * 16777619) ^ (uint8_t)*p++;
+				return (size_t)result;
+			}
+		};
+	#endif
 
 	template<> struct hash<u16string_view>
 	{
@@ -599,6 +614,12 @@ namespace eastl
 			    EA_CONSTEXPR inline u16string_view operator "" _sv(const char16_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
 			    EA_CONSTEXPR inline u32string_view operator "" _sv(const char32_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
 			    EA_CONSTEXPR inline wstring_view operator "" _sv(const wchar_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+
+				// C++20 char8_t support.
+				#if EA_CHAR8_UNIQUE
+					EA_CONSTEXPR inline u8string_view operator "" sv(const char8_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+					EA_CONSTEXPR inline u8string_view operator "" _sv(const char8_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+				#endif
 		    }
 	    }
 		EA_RESTORE_VC_WARNING() // warning: 4455

--- a/scripts/CMake/CommonCppFlags.cmake
+++ b/scripts/CMake/CommonCppFlags.cmake
@@ -1,4 +1,20 @@
 #-------------------------------------------------------------------------------------------
+# Compiler Flag Detection
+#-------------------------------------------------------------------------------------------
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag("-fchar8_t" EASTL_HAS_FCHAR8T_FLAG)
+check_cxx_compiler_flag("/Zc:char8_t" EASTL_HAS_ZCCHAR8T_FLAG)
+
+if(EASTL_HAS_FCHAR8T_FLAG)
+    set(EASTL_CHAR8T_FLAG "-fchar8_t")
+    set(EASTL_NO_CHAR8T_FLAG "-fno-char8_t")
+elseif(EASTL_HAS_ZCCHAR8T_FLAG)
+    set(EASTL_CHAR8T_FLAG "/Zc:char8_t")
+    set(EASTL_NO_CHAR8T_FLAG "/Zc:char8_t-")
+endif()
+
+#-------------------------------------------------------------------------------------------
 # Compiler Flags
 #-------------------------------------------------------------------------------------------
 if(UNIX AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 # Temporary logic to build a subset of tests with char8_t support since the
 # benchmark code and underlying submodules (particularly EAStdC) don't
 # currently compile if the full project is built with these flags enabled.
+#
+# An additional define is present (EASTL_EXPECT_CHAR8T_SUPPORT) if a flag
+# is successfully found to allow tests to fail themselves at compile time
+# if the define is present but EA_CHAR8_UNIQUE isn't set.
 if (EASTL_BUILD_CHAR8T_TESTS)
     check_cxx_compiler_flag(-fchar8_t COMPILER_SUPPORTS_GNU_CHAR8T_FLAG)
     check_cxx_compiler_flag(/Zc:char8_t COMPILER_SUPPORTS_MSVC_CHAR8T_FLAG)
@@ -48,9 +52,11 @@ if (EASTL_BUILD_CHAR8T_TESTS)
     if (COMPILER_SUPPORTS_GNU_CHAR8T_FLAG)
         message(STATUS "Building with char8_t support in tests.")
         set_source_files_properties("source/TestString.cpp" "source/TestStringView.cpp" PROPERTIES COMPILE_FLAGS -fchar8_t)
+        add_definitions(-DEASTL_EXPECT_CHAR8T_SUPPORT)
     elseif (COMPILER_SUPPORTS_MSVC_CHAR8T_FLAG)
         message(STATUS "Building with char8_t support in tests.")
         set_source_files_properties("source/TestString.cpp" "source/TestStringView.cpp" PROPERTIES COMPILE_FLAGS /Zc:char8_t)
+        add_definitions(-DEASTL_EXPECT_CHAR8T_SUPPORT)
     else()
         message(NOTICE "Cannot build with char8_t support in tests: compiler does not support any known flags.")
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,13 @@
 #-------------------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.1)
 project(EASTLTest CXX)
+include(CheckCXXCompilerFlag)
 include(CTest)
+
+#-------------------------------------------------------------------------------------------
+# Options
+#-------------------------------------------------------------------------------------------
+option(EASTL_BUILD_CHAR8T_TESTS "Enable building individual tests with char8_t support." OFF)
 
 #-------------------------------------------------------------------------------------------
 # Defines
@@ -30,6 +36,24 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pointer-bool-conversion -Wno-unknown-warning-option")
+endif()
+
+# Temporary logic to build a subset of tests with char8_t support since the
+# benchmark code and underlying submodules (particularly EAStdC) don't
+# currently compile if the full project is built with these flags enabled.
+if (EASTL_BUILD_CHAR8T_TESTS)
+    check_cxx_compiler_flag(-fchar8_t COMPILER_SUPPORTS_GNU_CHAR8T_FLAG)
+    check_cxx_compiler_flag(/Zc:char8_t COMPILER_SUPPORTS_MSVC_CHAR8T_FLAG)
+
+    if (COMPILER_SUPPORTS_GNU_CHAR8T_FLAG)
+        message(STATUS "Building with char8_t support in tests.")
+        set_source_files_properties("source/TestString.cpp" "source/TestStringView.cpp" PROPERTIES COMPILE_FLAGS -fchar8_t)
+    elseif (COMPILER_SUPPORTS_MSVC_CHAR8T_FLAG)
+        message(STATUS "Building with char8_t support in tests.")
+        set_source_files_properties("source/TestString.cpp" "source/TestStringView.cpp" PROPERTIES COMPILE_FLAGS /Zc:char8_t)
+    else()
+        message(NOTICE "Cannot build with char8_t support in tests: compiler does not support any known flags.")
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,13 +7,7 @@
 #-------------------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.1)
 project(EASTLTest CXX)
-include(CheckCXXCompilerFlag)
 include(CTest)
-
-#-------------------------------------------------------------------------------------------
-# Options
-#-------------------------------------------------------------------------------------------
-option(EASTL_BUILD_CHAR8T_TESTS "Enable building individual tests with char8_t support." OFF)
 
 #-------------------------------------------------------------------------------------------
 # Defines
@@ -38,28 +32,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pointer-bool-conversion -Wno-unknown-warning-option")
 endif()
 
-# Temporary logic to build a subset of tests with char8_t support since the
-# benchmark code and underlying submodules (particularly EAStdC) don't
-# currently compile if the full project is built with these flags enabled.
-#
-# An additional define is present (EASTL_EXPECT_CHAR8T_SUPPORT) if a flag
-# is successfully found to allow tests to fail themselves at compile time
-# if the define is present but EA_CHAR8_UNIQUE isn't set.
-if (EASTL_BUILD_CHAR8T_TESTS)
-    check_cxx_compiler_flag(-fchar8_t COMPILER_SUPPORTS_GNU_CHAR8T_FLAG)
-    check_cxx_compiler_flag(/Zc:char8_t COMPILER_SUPPORTS_MSVC_CHAR8T_FLAG)
-
-    if (COMPILER_SUPPORTS_GNU_CHAR8T_FLAG)
-        message(STATUS "Building with char8_t support in tests.")
-        set_source_files_properties("source/TestString.cpp" "source/TestStringView.cpp" PROPERTIES COMPILE_FLAGS -fchar8_t)
-        add_definitions(-DEASTL_EXPECT_CHAR8T_SUPPORT)
-    elseif (COMPILER_SUPPORTS_MSVC_CHAR8T_FLAG)
-        message(STATUS "Building with char8_t support in tests.")
-        set_source_files_properties("source/TestString.cpp" "source/TestStringView.cpp" PROPERTIES COMPILE_FLAGS /Zc:char8_t)
-        add_definitions(-DEASTL_EXPECT_CHAR8T_SUPPORT)
-    else()
-        message(NOTICE "Cannot build with char8_t support in tests: compiler does not support any known flags.")
-    endif()
+# Parts of the test suite fail to compile if char8_t is enabled, so we
+# disable it and only enable for specific source files later on.
+if (EASTL_NO_CHAR8T_FLAG)
+    add_compile_options(${EASTL_NO_CHAR8T_FLAG})
 endif()
 
 #-------------------------------------------------------------------------------------------
@@ -68,6 +44,15 @@ endif()
 file(GLOB EASTLTEST_SOURCES "source/*.cpp" "source/*.inl" "source/*.h")
 set(SOURCES ${EASTLTEST_SOURCES})
 
+# Compile a subset of tests with explicit char8_t support if available.
+if (EASTL_CHAR8T_FLAG)
+    message(STATUS "Building with char8_t support in tests.")
+    set(EASTLTEST_CHAR8T_SOURCES "source/TestString.cpp" "source/TestStringView.cpp")
+
+    set_source_files_properties(${EASTLTEST_CHAR8T_SOURCES} PROPERTIES
+        COMPILE_FLAGS ${EASTL_CHAR8T_FLAG}
+        COMPILE_DEFINITIONS "EASTL_EXPECT_CHAR8T_SUPPORT")
+endif()
 
 #-------------------------------------------------------------------------------------------
 # Executable definition

--- a/test/source/TestString.cpp
+++ b/test/source/TestString.cpp
@@ -18,15 +18,19 @@ using namespace eastl;
 #include "TestString.inl"
 
 #define TEST_STRING_NAME TestBasicStringW
-#define LITERAL(x) EA_WCHAR(x) 
+#define LITERAL(x) EA_WCHAR(x)
+#include "TestString.inl"
+
+#define TEST_STRING_NAME TestBasicString8
+#define LITERAL(x) EA_CHAR8(x)
 #include "TestString.inl"
 
 #define TEST_STRING_NAME TestBasicString16
-#define LITERAL(x) EA_CHAR16(x) 
+#define LITERAL(x) EA_CHAR16(x)
 #include "TestString.inl"
 
 #define TEST_STRING_NAME TestBasicString32
-#define LITERAL(x) EA_CHAR32(x) 
+#define LITERAL(x) EA_CHAR32(x)
 #include "TestString.inl"
 
 int TestString()
@@ -38,6 +42,11 @@ int TestString()
 
 	nErrorCount += TestBasicStringW<eastl::basic_string<wchar_t, StompDetectAllocator>>();
 	nErrorCount += TestBasicStringW<eastl::wstring>();
+
+#if EA_CHAR8_UNIQUE
+	nErrorCount += TestBasicString8<eastl::basic_string<char8_t, StompDetectAllocator>>();
+	nErrorCount += TestBasicString8<eastl::u8string>();
+#endif
 
 	nErrorCount += TestBasicString16<eastl::basic_string<char16_t, StompDetectAllocator>>();
 	nErrorCount += TestBasicString16<eastl::u16string>();
@@ -54,6 +63,11 @@ int TestString()
 
 	nErrorCount += TestBasicStringW<eastl::basic_string<wchar_t, CountingAllocator>>();
 	VERIFY(CountingAllocator::getActiveAllocationCount() == 0); 
+
+#if EA_CHAR8_UNIQUE
+	nErrorCount += TestBasicString8<eastl::basic_string<char8_t, CountingAllocator>>();
+	VERIFY(CountingAllocator::getActiveAllocationCount() == 0);
+#endif
 
 	nErrorCount += TestBasicString16<eastl::basic_string<char16_t, CountingAllocator>>();
 	VERIFY(CountingAllocator::getActiveAllocationCount() == 0); 
@@ -101,6 +115,7 @@ int TestString()
 		VERIFY(L"cplusplus"s == L"cplusplus");
 		VERIFY(u"cplusplus"s == u"cplusplus");
 		VERIFY(U"cplusplus"s == U"cplusplus");
+		VERIFY(u8"cplusplus"s == u8"cplusplus");
 	}
 	#endif
 

--- a/test/source/TestString.cpp
+++ b/test/source/TestString.cpp
@@ -12,6 +12,11 @@
 
 using namespace eastl;
 
+// Verify char8_t support is present if the test build requested it.
+#if defined(EASTL_EXPECT_CHAR8T_SUPPORT) && !EA_CHAR8_UNIQUE
+static_assert(false, "Building with char8_t tests enabled, but EA_CHAR8_UNIQUE evaluates to false.");
+#endif
+
 // inject string literal string conversion macros into the unit tests
 #define TEST_STRING_NAME TestBasicString
 #define LITERAL(x) x

--- a/test/source/TestString.inl
+++ b/test/source/TestString.inl
@@ -372,11 +372,11 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str(typename StringType::CtorConvert(), EA_WCHAR("123456789"));
-		//     VERIFY(str == LITERAL("123456789"));
-		//     VERIFY(str.validate());
-		// #endif
+		#if defined(EA_WCHAR)
+		    StringType str(typename StringType::CtorConvert(), EA_WCHAR("123456789"));
+		    VERIFY(str == LITERAL("123456789"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -405,11 +405,11 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str(typename StringType::CtorConvert(), EA_WCHAR("123456789"), 4);
-		//     VERIFY(str == LITERAL("1234"));
-		//     VERIFY(str.validate());
-		// #endif
+		#if defined(EA_WCHAR)
+		    StringType str(typename StringType::CtorConvert(), EA_WCHAR("123456789"), 4);
+		    VERIFY(str == LITERAL("1234"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -438,11 +438,11 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str(typename StringType::CtorConvert(), eastl::basic_string<wchar_t, StringType::allocator_type>(EA_WCHAR("123456789")));
-		//     VERIFY(str == LITERAL("123456789"));
-		//     VERIFY(str.validate());
-		// #endif
+		#if defined(EA_WCHAR)
+		    StringType str(typename StringType::CtorConvert(), eastl::basic_string<wchar_t, typename StringType::allocator_type>(EA_WCHAR("123456789")));
+		    VERIFY(str == LITERAL("123456789"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -786,12 +786,12 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
-		//     str.assign_convert(EA_WCHAR("123456789"));
-		//     VERIFY(str == LITERAL("123456789"));
-		//     VERIFY(str.validate());
-		// #endif
+		#if defined(EA_WCHAR)
+		    StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+		    str.assign_convert(EA_WCHAR("123456789"));
+		    VERIFY(str == LITERAL("123456789"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -823,12 +823,12 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
-		//     str.assign_convert(EA_WCHAR("123456789"), 3);
-		//     VERIFY(str == LITERAL("123"));
-		//     VERIFY(str.validate());
-		// #endif
+		#if defined(EA_WCHAR)
+		    StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+		    str.assign_convert(EA_WCHAR("123456789"), 3);
+		    VERIFY(str == LITERAL("123"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -866,14 +866,14 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
-		//     eastl::basic_string<wchar_t> str2(EA_WCHAR("123456789"));
+		#if defined(EA_WCHAR)
+		    StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+		    eastl::basic_string<wchar_t> str2(EA_WCHAR("123456789"));
 
-		//     str.assign_convert(str2);
-		//     VERIFY(str == LITERAL("123456789"));
-		//     VERIFY(str.validate());
-		// #endif
+		    str.assign_convert(str2);
+		    VERIFY(str == LITERAL("123456789"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -1288,12 +1288,12 @@ int TEST_STRING_NAME()
 		#endif
 		}
 		{
-		// #if defined(EA_WCHAR)
-		//     StringType str;
-		//     str.append_convert(EA_WCHAR("123456789"));
-		//     VERIFY(str == LITERAL("123456789"));
-		//     VERIFY(str.validate());
-		// #endif
+		#if defined(EA_WCHAR)
+		    StringType str;
+		    str.append_convert(EA_WCHAR("123456789"));
+		    VERIFY(str == LITERAL("123456789"));
+		    VERIFY(str.validate());
+		#endif
 		}
 	}
 
@@ -1324,14 +1324,14 @@ int TEST_STRING_NAME()
 			VERIFY(str.validate());
 		#endif
 		}
-		// {
-		// #if defined(EA_WCHAR)
-		//     StringType str;
-		//     str.append_convert(EA_WCHAR("123456789"), 5);
-		//     VERIFY(str == LITERAL("12345"));
-		//     VERIFY(str.validate());
-		// #endif
-		// }
+		{
+		#if defined(EA_WCHAR)
+		    StringType str;
+		    str.append_convert(EA_WCHAR("123456789"), 5);
+		    VERIFY(str == LITERAL("12345"));
+		    VERIFY(str.validate());
+		#endif
+		}
 	}
 
 	// template <typename OtherStringType>
@@ -1355,20 +1355,20 @@ int TEST_STRING_NAME()
 		}
 		{
 		#if defined(EA_CHAR32)
-			StringType str; 
+			StringType str;
 			str.append_convert(eastl::string32(EA_CHAR32("123456789")));
 			VERIFY(str == LITERAL("123456789"));
 			VERIFY(str.validate());
 		#endif
 		}
-		// {
-		// #if defined(EA_WCHAR)
-		//     StringType str = EA_WCHAR("123456789");
-		//     str.append_convert(str, 5);
-		//     VERIFY(str == LITERAL("12345"));
-		//     VERIFY(str.validate());
-		// #endif
-		// }
+		{
+		#if defined(EA_WCHAR)
+		    StringType str;
+		    str.append_convert(eastl::wstring(EA_WCHAR("123456789")));
+		    VERIFY(str == LITERAL("123456789"));
+		    VERIFY(str.validate());
+		#endif
+		}
 	}
 
 	// void push_back(value_type c);

--- a/test/source/TestStringView.cpp
+++ b/test/source/TestStringView.cpp
@@ -14,15 +14,19 @@
 #include "TestStringView.inl"
 
 #define TEST_STRING_NAME TestBasicStringViewW
-#define LITERAL(x) EA_WCHAR(x) 
+#define LITERAL(x) EA_WCHAR(x)
+#include "TestStringView.inl"
+
+#define TEST_STRING_NAME TestBasicStringView8
+#define LITERAL(x) EA_CHAR8(x)
 #include "TestStringView.inl"
 
 #define TEST_STRING_NAME TestBasicStringView16
-#define LITERAL(x) EA_CHAR16(x) 
+#define LITERAL(x) EA_CHAR16(x)
 #include "TestStringView.inl"
 
 #define TEST_STRING_NAME TestBasicStringView32
-#define LITERAL(x) EA_CHAR32(x) 
+#define LITERAL(x) EA_CHAR32(x)
 #include "TestStringView.inl"
 
 
@@ -37,6 +41,11 @@ int TestStringView()
 	nErrorCount += TestBasicStringViewW<eastl::basic_string_view<wchar_t>>();
 	nErrorCount += TestBasicStringViewW<eastl::wstring_view>();
 
+#if EA_CHAR8_UNIQUE
+	nErrorCount += TestBasicStringView8<eastl::basic_string_view<char8_t>>();
+	nErrorCount += TestBasicStringView8<eastl::u8string_view>();
+#endif
+
 	nErrorCount += TestBasicStringView16<eastl::basic_string_view<char16_t>>();
 	nErrorCount += TestBasicStringView16<eastl::u16string_view>();
 
@@ -47,6 +56,7 @@ int TestStringView()
 
 
 	// constexpr string_view operator "" sv(const char* str, size_t len) noexcept;
+	// constexpr u8string_view operator "" sv(const char8_t* str, size_t len) noexcept;
 	// constexpr u16string_view operator "" sv(const char16_t* str, size_t len) noexcept;
 	// constexpr u32string_view operator "" sv(const char32_t* str, size_t len) noexcept;
 	// constexpr wstring_view   operator "" sv(const wchar_t* str, size_t len) noexcept;
@@ -56,8 +66,10 @@ int TestStringView()
 		VERIFY(L"cplusplus"_sv.compare(L"cplusplus") == 0);
 		VERIFY(u"cplusplus"_sv.compare(u"cplusplus") == 0);
 		VERIFY(U"cplusplus"_sv.compare(U"cplusplus") == 0);
+		VERIFY(u8"cplusplus"_sv.compare(u8"cplusplus") == 0);
 
 		static_assert(eastl::is_same_v<decltype("abcdef"_sv), eastl::string_view>, "string_view literal type mismatch");
+		static_assert(eastl::is_same_v<decltype(u8"abcdef"_sv), eastl::u8string_view>, "string_view literal type mismatch");
 		static_assert(eastl::is_same_v<decltype(u"abcdef"_sv), eastl::u16string_view>, "string_view literal type mismatch");
 		static_assert(eastl::is_same_v<decltype(U"abcdef"_sv), eastl::u32string_view>, "string_view literal type mismatch");
 		static_assert(eastl::is_same_v<decltype(L"abcdef"_sv), eastl::wstring_view>, "string_view literal type mismatch");
@@ -67,6 +79,7 @@ int TestStringView()
 		// VERIFY(L"cplusplus"sv.compare(L"cplusplus") == 0);
 		// VERIFY(u"cplusplus"sv.compare(u"cplusplus") == 0);
 		// VERIFY(U"cplusplus"sv.compare(U"cplusplus") == 0);
+		// VERIFY(u8"cplusplus"sv.compare(u8"cplusplus") == 0);
 	}
 	#endif
 

--- a/test/source/TestStringView.cpp
+++ b/test/source/TestStringView.cpp
@@ -7,6 +7,10 @@
 #include <EASTL/numeric_limits.h>
 #include <EASTL/string_view.h>
 
+// Verify char8_t support is present if the test build requested it.
+#if defined(EASTL_EXPECT_CHAR8T_SUPPORT) && !EA_CHAR8_UNIQUE
+static_assert(false, "Building with char8_t tests enabled, but EA_CHAR8_UNIQUE evaluates to false.");
+#endif
 
 // this mess is required inorder to inject string literal string conversion macros into the unit tests
 #define TEST_STRING_NAME TestBasicStringView


### PR DESCRIPTION
* Added `operator ""sv` support for creating a `string_view` from a `char8_t` string literal. Additionally added the `operator ""_sv`to enable testing.
* Added `operator ""s` support for creating a `string` from a `char8_t` string literal.
* Added specializations of `eastl::hash` for both `u8string` and `u8string_view`.

These are only enabled when `char8_t` is a distinct type under C++20, since otherwise the existing `char`-based definitions are sufficient.

* Added test variants for `u8string` and `u8string_view`.
* Added support for some commented-out tests around `wchar_t` support with strings.

Unfortunately there's a number of errors from EAStdC and some other submodules when compiling the full test suite in C++20 mode due to lots of structures and signatures mixing `char` and `char8_t`, so the results from these wouldn't show in CI (even under MSVC, since [the current setup doesn't support the `/Zc:char8_t` flag](https://travis-ci.org/electronicarts/EASTL/jobs/641814300#L110)).

I've added a build option (`EASTL_BUILD_CHAR8T_TESTS`) which will attempt to build just the string/string_view tests with `char8_t` support if CMake is happy that the compiler supports either the `-fchar8_t` or `/Zc:char8_t` flags. As the Clang compiler in the Travis environment is version 7, which supposedly supports it, I've added a matrix to the CI setup to enable this (and if it works, it should show up in the build log). Locally I've verified all the tests pass with both GCC 9.2.0 and Clang 9 with this option both set and unset.

I've had to add a few additional overloads for DecodePart to handle string test cases where `append_convert` would be called with the same source and destination character types for `char8_t` and `wchar_t`, or where the destination buffer was `char8_t`-based. These just cast the parameters to `char*`s and forward to the appropriate overloads.