### PR TITLE
add enable_shared_from_this::weak_from_this() present since C++17

### DIFF
--- a/include/EASTL/internal/enable_shared.h
+++ b/include/EASTL/internal/enable_shared.h
@@ -45,6 +45,12 @@ namespace eastl
 		shared_ptr<const T> shared_from_this() const
 			{ return shared_ptr<const T>(mWeakPtr); }
 
+		weak_ptr<T> weak_from_this()
+			{ return mWeakPtr; }
+
+		weak_ptr<const T> weak_from_this() const
+			{ return mWeakPtr; }
+
 	public: // This is public because the alternative fails on some compilers that we need to support.
 		mutable weak_ptr<T> mWeakPtr;
 

--- a/test/source/TestSmartPtr.cpp
+++ b/test/source/TestSmartPtr.cpp
@@ -1522,6 +1522,22 @@ static int Test_weak_ptr()
 		EATEST_VERIFY(!(pFoo < qFoo) && !(qFoo < pFoo)); // p and q share ownership
 	}
 
+	{   // weak_from_this const
+		shared_ptr<const foo> pFoo(new foo);
+		weak_ptr<const foo> qFoo = pFoo->weak_from_this();
+
+		EATEST_VERIFY(pFoo == qFoo.lock());
+		EATEST_VERIFY(!(pFoo < qFoo.lock()) && !(qFoo.lock() < pFoo)); // p and q share ownership
+	}
+
+	{   // weak_from_this
+		shared_ptr<foo> pFoo(new foo);
+		weak_ptr<foo> qFoo = pFoo->weak_from_this();
+
+		EATEST_VERIFY(pFoo == qFoo.lock());
+		EATEST_VERIFY(!(pFoo < qFoo.lock()) && !(qFoo.lock() < pFoo)); // p and q share ownership
+	}
+	
 	return nErrorCount;
 }
 


### PR DESCRIPTION
Add enable_shared_from_this::weak_from_this() because it's now available since C++17.
cf. https://en.cppreference.com/w/cpp/memory/enable_shared_from_this/weak_from_this