### PR TITLE
Fix circular dependency in fixed_function.h

### DIFF
--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -10,7 +10,7 @@
 #include <EASTL/internal/config.h>
 #include <EASTL/type_traits.h>
 #include <EASTL/iterator.h>
-#include <EASTL/functional.h>
+#include <EASTL/internal/functional_base.h>
 #include <EASTL/internal/move_help.h>
 #include <EABase/eahave.h>
 

--- a/test/source/TestFixedFunction.cpp
+++ b/test/source/TestFixedFunction.cpp
@@ -2,10 +2,11 @@
 // Copyright (c) Electronic Arts Inc. All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
 
+#include <EASTL/fixed_function.h>
+
 #include <EABase/eabase.h>
 #include <EAAssert/eaassert.h>
 #include "EASTLTest.h"
-#include <EASTL/fixed_function.h>
 #include <EASTL/numeric.h>
 
 EA_DISABLE_ALL_VC_WARNINGS()

--- a/test/source/TestFixedFunction.cpp
+++ b/test/source/TestFixedFunction.cpp
@@ -2,10 +2,13 @@
 // Copyright (c) Electronic Arts Inc. All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
 
-#include <EASTL/fixed_function.h>
-
 #include <EABase/eabase.h>
 #include <EAAssert/eaassert.h>
+
+// Included prior to EASTLTest.h to guard against the following bug resurfacing:
+// https://github.com/electronicarts/EASTL/issues/275
+#include <EASTL/fixed_function.h>
+
 #include "EASTLTest.h"
 #include <EASTL/numeric.h>
 


### PR DESCRIPTION
Fixes #275.

The referenced issue notes a compilation error that occurs when `fixed_function.h` is included ahead of `functional.h`. This can be demonstrated by just compiling a lone source file with the following:
```cpp
#include <EASTL/fixed_function.h>
```

This results in the following (shortened) inclusion order as dumped via MSVC's `/showIncludes` option, and error:
```
include\EASTL\fixed_function.h
 include\EASTL\internal\function_detail.h      # function_detail from fixed_function...
  include\EASTL\utility.h                               
   include\EASTL\functional.h                  # utility requires reference_wrapper traits...
    include\EASTL\internal\mem_fn.h
    include\EASTL\internal\function.h
     include\EASTL\internal\function_detail.h  # Oops!
include\EASTL\internal\function.h(31): error C2143: syntax error: missing ',' before '<'
include\EASTL\internal\function.h(127): note: see reference to class template instantiation 'eastl::function<R(Args...)>' being compiled
include\EASTL\internal\function.h(34): error C2061: syntax error: identifier 'function_detail'
include\EASTL\internal\function.h(36): error C2653: 'Base': is not a class or namespace name
include\EASTL\internal\function.h(36): error C2146: syntax error: missing ';' before identifier 'result_type'
```

This doesn't show up in the test suite as-is since `functional.h` is included (via `EASTLTest.h` and `algorithm.h`) prior to `fixed_function.h`, so the first commit reorders those includes to try and prevent this issue going by undetected.

As `utility.h` only requires the `eastl::reference_wrapper` type traits, I've opted to fix this by just pulling in `functional_base.h` (instead of `functional.h`).

This will affect users if they're expecting the full breadth of `functional.h` to have been made available, so an alternative could be instead to just make `fixed_function.h` include `functional.h` (instead of `function_detail.h`) at the expense of making that header unnecessarily large.