### PR TITLE
fix bitvector iterators

### DIFF
--- a/include/EASTL/bitvector.h
+++ b/include/EASTL/bitvector.h
@@ -766,7 +766,7 @@ namespace eastl
 	typename bitvector<Allocator, Element, Container>::iterator
 	bitvector<Allocator, Element, Container>::begin() EA_NOEXCEPT
 	{
-		return iterator(&mContainer[0], 0);
+		return iterator(mContainer.begin(), 0);
 	}
 
 
@@ -774,7 +774,7 @@ namespace eastl
 	typename bitvector<Allocator, Element, Container>::const_iterator
 	bitvector<Allocator, Element, Container>::begin() const EA_NOEXCEPT
 	{
-		return const_iterator(&mContainer[0], 0);
+		return const_iterator(mContainer.begin(), 0);
 	}
 
 
@@ -782,7 +782,7 @@ namespace eastl
 	typename bitvector<Allocator, Element, Container>::const_iterator
 	bitvector<Allocator, Element, Container>::cbegin() const EA_NOEXCEPT
 	{
-		return const_iterator(&mContainer[0], 0);
+		return const_iterator(mContainer.begin(), 0);
 	}
 
 

--- a/test/source/TestBitVector.cpp
+++ b/test/source/TestBitVector.cpp
@@ -165,6 +165,11 @@ int TestBitVector()
 
 			bv0.assign(boolArray, boolArray + EAArrayCount(boolArray));
 			EATEST_VERIFY(bv0 == bitvector<>(boolArray, boolArray + EAArrayCount(boolArray)));
+
+			bv0.resize(0);
+			EATEST_VERIFY(bv0.begin()==bv0.end());//should not crash
+			bv3.resize(0);
+			EATEST_VERIFY(bv0 == bv3);
 		}
 	}
 


### PR DESCRIPTION
use mContainer.begin() instead of &mContainer[0],
since the latter causes out of bounds exception in non release build