### PR TITLE
fixed unique_ptr::reset() instructions order. Internal pointer must be updated before calling deleting object

### DIFF
--- a/include/EASTL/unique_ptr.h
+++ b/include/EASTL/unique_ptr.h
@@ -210,10 +210,8 @@ namespace eastl
 		{
 			if (pValue != mPair.first())
 			{
-				if (mPair.first())
-					get_deleter()(mPair.first());
-
-				mPair.first() = pValue;
+				if (auto first = exchange(mPair.first(), pValue))
+					get_deleter()(first);
 			}
 		}
 

--- a/test/source/TestSmartPtr.cpp
+++ b/test/source/TestSmartPtr.cpp
@@ -392,6 +392,20 @@ namespace SmartPtrTest
 		int mX;
 	};
 
+	struct CheckUPtrEmptyInDestructor
+	{
+		~CheckUPtrEmptyInDestructor()
+		{
+			if(mpUPtr)
+				mCheckUPtrEmpty = (*mpUPtr == nullptr);
+		}
+
+		eastl::unique_ptr<CheckUPtrEmptyInDestructor>* mpUPtr{};
+		static bool mCheckUPtrEmpty;
+	};
+
+	bool CheckUPtrEmptyInDestructor::mCheckUPtrEmpty = false;
+
 } // namespace SmartPtrTest
 
 
@@ -540,6 +554,16 @@ static int Test_unique_ptr()
 
 			EATEST_VERIFY(sLocalDeleterCalled == false);
 		}
+	}
+
+	{
+		// Test that unique_ptr internal pointer is reset before calling the destructor
+		CheckUPtrEmptyInDestructor::mCheckUPtrEmpty = false;
+
+		unique_ptr<CheckUPtrEmptyInDestructor> uptr(new CheckUPtrEmptyInDestructor);
+		uptr->mpUPtr = &uptr;
+		uptr.reset();
+		EATEST_VERIFY(CheckUPtrEmptyInDestructor::mCheckUPtrEmpty);
 	}
 
 	{


### PR DESCRIPTION
Currently, unique_ptr::reset(), delete the object (if present) and then change the internal pointer.
But, according to standard (see https://en.cppreference.com/w/cpp/memory/unique_ptr/reset), the operation must be done in this order : 
* Saves a copy of the current pointer old_ptr = current_ptr
* Overwrites the current pointer with the argument current_ptr = ptr
* If the old pointer was non-empty, deletes the previously managed object if(old_ptr) get_deleter()(old_ptr).

It make sense, in order to avoid having a internal pointer on an object that will be destroyed.