### PR TITLE
eastl::shared_ptr<>::reset(): function not thread safe

### DIFF
--- a/include/EASTL/shared_ptr.h
+++ b/include/EASTL/shared_ptr.h
@@ -162,15 +162,11 @@ namespace eastl
 	inline void ref_count_sp::release()
 	{
 		EASTL_ASSERT((mRefCount > 0) && (mWeakRefCount > 0));
-		if(Internal::atomic_decrement(&mRefCount) > 0)
-			Internal::atomic_decrement(&mWeakRefCount);
-		else
-		{
+		if(Internal::atomic_decrement(&mRefCount) == 0)
 			free_value();
 
-			if(Internal::atomic_decrement(&mWeakRefCount) == 0)
-				free_ref_count_sp();
-		}
+		if(Internal::atomic_decrement(&mWeakRefCount) == 0)
+			free_ref_count_sp();
 	}
 
 	inline void ref_count_sp::weak_addref() EA_NOEXCEPT

--- a/test/source/TestSmartPtr.cpp
+++ b/test/source/TestSmartPtr.cpp
@@ -21,6 +21,7 @@
 #include <EASTL/unique_ptr.h>
 #include <EASTL/weak_ptr.h>
 #include <eathread/eathread_thread.h>
+#include <future>
 
 EA_DISABLE_ALL_VC_WARNINGS()
 #include <stdio.h>
@@ -1392,6 +1393,29 @@ static int Test_shared_ptr()
 #endif
 
 
+template<typename Fct1, typename Fct2>
+void Try_to_invoke_2tasks_at_same_time(const Fct1& fct1, const Fct2& fct2)
+{
+	std::atomic_uint32_t waitThread = true;
+	std::atomic_uint32_t waitMainThread = true;
+
+	std::future<void> f1 = std::async(
+		[&]
+		{
+			waitThread = false;
+			while(waitMainThread)
+			{
+			}
+			fct1();
+		});
+
+	waitMainThread = false;
+	while(waitThread)
+	{
+	}
+	fct2();
+}
+
 static int Test_shared_ptr_thread()
 {
 	using namespace SmartPtrTest;
@@ -1485,6 +1509,84 @@ static int Test_shared_ptr_thread()
 
 	EATEST_VERIFY(A::mCount == 0);
 	TestObject::Reset();
+
+	{
+		// Check that counter inside shared_ptr<> is thread safe when using reset().
+		for(uint32_t counter = 0; counter < 200000; ++counter)
+		{
+			eastl::shared_ptr<double> valueSPtr1(new double(0.));
+			eastl::shared_ptr<double> valueSPtr2(valueSPtr1);
+
+			Try_to_invoke_2tasks_at_same_time(
+				[&]
+				{
+					valueSPtr1.reset();
+				},
+				[&]
+				{
+					valueSPtr2.reset();
+				});
+		}
+	}
+
+	{
+		// Check that counter inside shared_ptr<> and weak_ptr<> is thread safe when using reset().
+		for(uint32_t counter = 0; counter < 200000; ++counter)
+		{
+			eastl::shared_ptr<double> valueSPtr(new double(0.));
+			eastl::weak_ptr<double> valueWPtr(valueSPtr);
+
+			Try_to_invoke_2tasks_at_same_time(
+				[&]
+				{
+					valueSPtr.reset();
+				},
+				[&]
+				{
+					valueWPtr.reset();
+				});
+		}
+	}
+
+	{
+		// Check that counter inside shared_ptr<> is thread safe when using operator =().
+		for(uint32_t counter = 0; counter < 200000; ++counter)
+		{
+			eastl::shared_ptr<double> valueSPtr(new double(0.));
+			eastl::weak_ptr<double> valueWPtr(valueSPtr);
+			eastl::shared_ptr<double> otherValueSPtr(new double(0.));
+
+			Try_to_invoke_2tasks_at_same_time(
+				[&]
+				{
+					valueSPtr = otherValueSPtr;
+				},
+				[&]
+				{
+					valueWPtr = otherValueSPtr;
+				});
+		}
+	}
+
+	{
+		// Check that counter inside shared_ptr<> and weak_ptr<> is thread safe when using operator =().
+		for(uint32_t counter = 0; counter < 200000; ++counter)
+		{
+			eastl::shared_ptr<double> valueSPtr(new double(0.));
+			eastl::shared_ptr<double> valueWPtr(valueSPtr);
+			eastl::shared_ptr<double> otherValueSPtr(new double(0.));
+
+			Try_to_invoke_2tasks_at_same_time(
+				[&]
+				{
+					valueSPtr = otherValueSPtr;
+				},
+				[&]
+				{
+					valueWPtr = otherValueSPtr;
+				});
+		}
+	}
 
 	return nErrorCount;
 }


### PR DESCRIPTION
reset() function of shared_ptr is not thread safe.
It takes so many times to understand/find where come from that memory leak I have in my code. The problem was so difficult to reproduce and isolate!

So here the code:
```
	inline void ref_count_sp::release()
	{
		EASTL_ASSERT((mRefCount > 0) && (mWeakRefCount > 0));
		if(Internal::atomic_decrement(&mRefCount) > 0)
			Internal::atomic_decrement(&mWeakRefCount);
		else
		{
			free_value();

			if(Internal::atomic_decrement(&mWeakRefCount) == 0)
				free_ref_count_sp();
		}
	}
```


If 2 threads, with 2 shared_ptr<> pointed the same value, and are calling the release() function at the same time, the `free_ref_count_sp();` could be not called.
It happens, when thread 1 is calling `Internal::atomic_decrement(&mWeakRefCount);` (due `m_RefCount > 0`) after the thread 2 call the code `if(Internal::atomic_decrement(&mWeakRefCount) == 0)`. In that case `free_ref_count_sp();` is not called, because on the thread 2, `mWeakRefCount` will have value 1.

The fix consist to remove that else condition and process each counter independently : 
```
	inline void ref_count_sp::release()
	{
		EASTL_ASSERT((mRefCount > 0) && (mWeakRefCount > 0));
		if(Internal::atomic_decrement(&mRefCount) == 0)
			free_value();

		if(Internal::atomic_decrement(&mWeakRefCount) == 0)
			free_ref_count_sp();
	}
```

I try to write UTest for that case. For the moment, I used std::future and std::async because it's easier for me. If I have to used EAThread, could you tell me the best eastl function to used instead.