### PR TITLE
default_delete for smart_ptr: generate a compilation error if type incomplete

### DIFF
--- a/include/EASTL/internal/smart_ptr.h
+++ b/include/EASTL/internal/smart_ptr.h
@@ -162,7 +162,10 @@ namespace eastl
 		default_delete(const default_delete<U>&, typename eastl::enable_if<is_convertible<U*, T*>::value>::type* = 0) EA_NOEXCEPT {}
 
 		void operator()(T* p) const EA_NOEXCEPT
-			{ delete p; }
+		{
+			static_assert(0 < sizeof(T), "can't delete an incomplete type");
+			delete p;
+		}
 	};
 
 
@@ -179,7 +182,10 @@ namespace eastl
 		default_delete(const default_delete<U[]>&, typename eastl::enable_if<Internal::is_array_cv_convertible<U*, T*>::value>::type* = 0) EA_NOEXCEPT {}
 
 		void operator()(T* p) const EA_NOEXCEPT
-			{ delete[] p; }
+		{
+			static_assert(0 < sizeof(T), "can't delete an incomplete type");
+			delete[] p;
+		}
 	};
 
 


### PR DESCRIPTION
   Hello,
in some cases, usage of eastl::unique_ptr<>/eastl::shared_ptr<> could lead to no call to the destructor of class.
I happens when the type is incomplete where inside the file where the reset()/~unique_ptr() is called.
Indeed, in that case, the compiler will allow to call delete on an incomplete type, which lead to free the memory without calling any destructor... :(

I propose to add the same test make inside MSVC std or LLVM, which means, testing the size of the type.

Note that I cannot write UnitTest for that. But here the code that will generates a problem with the current implementation.
Code in reset_unique.cpp:
```
eastl::unique_ptr<Foo> p = UnitTest::CreateFoo();
p.reset(); // ~Foo() won't be called!
```

Code in create_foo.h:
```
eastl::unique_ptr<Foo> CreateFoo();
```

Code in create_foo.cpp:
```
struct Foo
{
	Foo() { printf("Foo()\n"); }
	~Foo() { printf("~Foo()\n"); }
};

eastl::unique_ptr<Foo> CreateFoo()
{
	return eastl::make_unique<Foo>();
}
```

Of course, this changes could generates few errors in existing code! On the project I'm working on, with more than 6500 references to eastl::unique_ptr<>, I had 6 compilation errors (and at least 1 true bug/memory leak).