### PR TITLE
Fix reverse adaptor when using on a rvalue range

### DIFF
--- a/include/EASTL/bonus/adaptors.h
+++ b/include/EASTL/bonus/adaptors.h
@@ -34,8 +34,9 @@ namespace eastl
 	template <typename Container>
 	struct reverse_wrapper
 	{
-		reverse_wrapper(Container& c) : mContainer(c) {}
-		Container& mContainer;
+		template <typename C>
+		reverse_wrapper(C&& c) : mContainer(eastl::forward<C>(c)) {}
+		Container mContainer;
 	};
 
 	template <typename Container>

--- a/test/source/TestExtra.cpp
+++ b/test/source/TestExtra.cpp
@@ -871,12 +871,26 @@ static int TestAdaptors()
 {
 	int nErrorCount = 0;
 
+	// reverse lvalue container
 	{
 		int int_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 		eastl::vector<int> original(begin(int_data), end(int_data));
 
 		eastl::vector<int> reversed;
 		for(auto& e : eastl::reverse(original))
+			reversed.push_back(e);
+
+		eastl::reverse(begin(original), end(original));
+		EATEST_VERIFY(reversed == original);
+	}
+
+	// reverse rvalue container
+	{
+		int int_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+		eastl::vector<int> original(begin(int_data), end(int_data));
+
+		eastl::vector<int> reversed;
+		for (auto& e : eastl::reverse(eastl::vector<int>(original)))
 			reversed.push_back(e);
 
 		eastl::reverse(begin(original), end(original));


### PR DESCRIPTION
Hello!
When trying the reverse adaptor on a rvalue container:

- There is this  warning on Visual 2015:

`warning C4239: nonstandard extension used : 'argument' : conversion from 'eastl::vector<int,eastl::allocator>' to 'eastl::vector<int,eastl::allocator> &'`

- And this error on Visual2017:

`error C2440: '<function-style-cast>': cannot convert from 'T' to 'eastl::reverse_wrapper<_Ty>'
        with
        [
            T=eastl::vector<int,eastl::allocator>
        ]
        and
        [
            _Ty=eastl::vector<int,eastl::allocator>
        ]
`

The member `Container& mContainer;` was wrong because on a lvalue *Container* it is still a reference (example: eastl::vector<int>&), and on a rvalue, it is just a copy (example: eastl::vector<int>) which is fine. So, no need to add a '&' to `Container mContainer;`.