### PR TITLE
Minor spelling and grammar corrections.

### DIFF
--- a/include/EASTL/any.h
+++ b/include/EASTL/any.h
@@ -9,7 +9,7 @@
 //
 // eastl::any is a type-safe container for single values of any type.  Our
 // implementation makes use of the "small local buffer" optimization to avoid
-// unnecessary dynamic memory allocation if the specified type is a eligible to
+// unnecessary dynamic memory allocation if the specified type is eligible to
 // be stored in its local buffer.  The user type must satisfy the size
 // requirements and must be no-throw move-constructible to qualify for the local
 // buffer optimization.
@@ -591,7 +591,7 @@ namespace eastl
 
 	// NOTE(rparolin): The runtime type check was commented out because in DLL builds the templated function pointer
 	// value will be different -- completely breaking the validation mechanism.  Due to the fact that eastl::any uses
-	// type erasure we can't refesh (on copy/move) the cached function pointer to the internal handler function because
+	// type erasure we can't refresh (on copy/move) the cached function pointer to the internal handler function because
 	// we don't statically know the type.
 	template <class ValueType>
 	inline const ValueType* any_cast(const any* pAny) EA_NOEXCEPT

--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -1008,7 +1008,7 @@ namespace eastl
 ///////////////////////////////////////////////////////////////////////////////
 // EASTL_OPERATOR_EQUALS_OTHER_ENABLED
 //
-// Defined as 0 or 1. Default is 0 until such day that it's deemeed safe.
+// Defined as 0 or 1. Default is 0 until such day that it's deemed safe.
 // When enabled, enables operator= for other char types, e.g. for code
 // like this:
 //     eastl::string8  s8;
@@ -1325,7 +1325,7 @@ namespace eastl
 //
 // Defined as 0 or 1; default is 1.
 // Specifies whether the min and max algorithms are available.
-// It may be useful to disable the min and max algorithems because sometimes
+// It may be useful to disable the min and max algorithms because sometimes
 // #defines for min and max exist which would collide with EASTL min and max.
 // Note that there are already alternative versions of min and max in EASTL
 // with the min_alt and max_alt functions. You can use these without colliding

--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -30,7 +30,7 @@
 //      trick of using: basic_string<char>(x).swap(x);
 //    - basic_string has a force_size() function, which unilaterally moves the string
 //      end position (mpEnd) to the given location. Useful for when the user writes
-//      into the string via some extenal means such as C strcpy or sprintf.
+//      into the string via some external means such as C strcpy or sprintf.
 //    - basic_string substr() deviates from the standard and returns a string with
 //		a copy of this->get_allocator()
 ///////////////////////////////////////////////////////////////////////////////
@@ -64,7 +64,7 @@
 //    - A reference count needs to exist with the string, which increases string memory usage.
 //    - With thread safety, atomic operations and mutex locks are expensive, especially
 //      on weaker memory systems such as console gaming platforms.
-//    - All non-const string accessor functions need to do a sharing check the the
+//    - All non-const string accessor functions need to do a sharing check then the
 //      first such check needs to detach the string. Similarly, all string assignments
 //      need to do a sharing check as well. If you access the string before doing an
 //      assignment, the assignment doesn't result in a shared string, because the string

--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -1718,7 +1718,7 @@ namespace eastl
 	{                                            // and some functions that need to clear our capacity (e.g. operator=) aren't supposed to require default-constructibility. 
 		clear();
 		this_type temp(eastl::move(*this));  // This is the simplest way to accomplish this, 
-		swap(temp);             // and it is as efficient as any other.
+		swap(temp);                          // and it is as efficient as any other.
 	}
 
 
@@ -1876,7 +1876,7 @@ namespace eastl
 				pointer pNewEnd = pNewData;
 				try
 				{   // To do: We are not handling exceptions properly below.  In particular we don't want to 
-					// call eastl::destruct on the entire range if only the first part of the range was costructed.
+					// call eastl::destruct on the entire range if only the first part of the range was constructed.
 					::new((void*)(pNewData + nPosSize)) value_type(eastl::forward<Args>(args)...);              // Because the old data is potentially being moved rather than copied, we need to move.
 					pNewEnd = NULL;                                                                             // Set to NULL so that in catch we can tell the exception occurred during the next call.
 					pNewEnd = eastl::uninitialized_move_ptr_if_noexcept(mpBegin, destPosition, pNewData);       // the value first, because it might possibly be a reference to the old data being moved.
@@ -1887,14 +1887,14 @@ namespace eastl
 					if(pNewEnd)
 						eastl::destruct(pNewData, pNewEnd);                                         // Destroy what has been constructed so far.
 					else
-						eastl::destruct(pNewData + nPosSize);                                       // The exception occurred during the first unintialized move, so destroy only the value at nPosSize.
+						eastl::destruct(pNewData + nPosSize);                                       // The exception occurred during the first uninitialized move, so destroy only the value at nPosSize.
 					DoFree(pNewData, nNewSize);
 					throw;
 				}
 			#else
 				::new((void*)(pNewData + nPosSize)) value_type(eastl::forward<Args>(args)...);                  // Because the old data is potentially being moved rather than copied, we need to move 
 				pointer pNewEnd = eastl::uninitialized_move_ptr_if_noexcept(mpBegin, destPosition, pNewData);   // the value first, because it might possibly be a reference to the old data being moved.
-				pNewEnd = eastl::uninitialized_move_ptr_if_noexcept(destPosition, mpEnd, ++pNewEnd);            // Question: with exceptions disabled, do we asssume all operations are noexcept and thus there's no need for uninitialized_move_ptr_if_noexcept?
+				pNewEnd = eastl::uninitialized_move_ptr_if_noexcept(destPosition, mpEnd, ++pNewEnd);            // Question: with exceptions disabled, do we assume all operations are noexcept and thus there's no need for uninitialized_move_ptr_if_noexcept?
 			#endif
 
 			eastl::destruct(mpBegin, mpEnd);

--- a/source/red_black_tree.cpp
+++ b/source/red_black_tree.cpp
@@ -125,7 +125,8 @@ namespace eastl
 	/// RBTreeRotateLeft
 	/// Does a left rotation about the given node. 
 	/// If you want to understand tree rotation, any book on algorithms will
-	/// discussion the topic in good detail.
+	/// discuss the topic in detail.
+	///
 	rbtree_node_base* RBTreeRotateLeft(rbtree_node_base* pNode, rbtree_node_base* pNodeRoot)
 	{
 		rbtree_node_base* const pNodeTemp = pNode->mpNodeRight;
@@ -154,7 +155,8 @@ namespace eastl
 	/// RBTreeRotateRight
 	/// Does a right rotation about the given node. 
 	/// If you want to understand tree rotation, any book on algorithms will
-	/// discussion the topic in good detail.
+	/// discuss the topic in detail.
+	///
 	rbtree_node_base* RBTreeRotateRight(rbtree_node_base* pNode, rbtree_node_base* pNodeRoot)
 	{
 		rbtree_node_base* const pNodeTemp = pNode->mpNodeLeft;


### PR DESCRIPTION
I was reading through some of the EASTL as a learning exercise and found a few minor typos, grammatical mishaps, or comment style inconsistencies. 

I've fixed them below and corrected the comment style to be more consistent with the rest of the file.