### PR TITLE
[EASTL 3.17.03]

### DIFF
--- a/doc/EASTL.natvis
+++ b/doc/EASTL.natvis
@@ -553,6 +553,12 @@
 </Type>
 
 
+
+<Type Name="eastl::atomic_flag">
+	<DisplayString>{mFlag.mAtomic}</DisplayString>
+</Type>
+
+
 <!-- TODO eastl::tuple -->
 
 

--- a/include/EASTL/internal/atomic/arch/x86/arch_x86_memory_barrier.h
+++ b/include/EASTL/internal/atomic/arch/x86/arch_x86_memory_barrier.h
@@ -27,9 +27,11 @@
 
 	#if 1
 
+		// 4459 : declaration of 'identifier' hides global declaration
+		// 4456 : declaration of 'identifier' hides previous local declaration
 		#define EASTL_ARCH_ATOMIC_CPU_MB()				\
 			{											\
-				EA_DISABLE_VC_WARNING(4456);			\
+				EA_DISABLE_VC_WARNING(4459 4456);		\
 				volatile long _;						\
 				_InterlockedExchangeAdd(&_, 0);			\
 				EA_RESTORE_VC_WARNING();				\

--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -89,8 +89,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef EASTL_VERSION
-	#define EASTL_VERSION   "3.17.01"
-	#define EASTL_VERSION_N  31701
+	#define EASTL_VERSION   "3.17.03"
+	#define EASTL_VERSION_N  31703
 #endif
 
 

--- a/test/source/TestLruCache.cpp
+++ b/test/source/TestLruCache.cpp
@@ -282,5 +282,59 @@ int TestLruCache()
 		}
 	}
 
+	// Test iteration
+	{
+		eastl::lru_cache<int, int> lc(5);
+		lc.insert_or_assign(0,10);
+		lc.insert_or_assign(1,11);
+		lc.insert_or_assign(2,12);
+		lc.insert_or_assign(3,13);
+		lc.insert_or_assign(4,14);
+
+		{ // test manual for-loop
+			int i = 0;
+			for (auto b = lc.begin(), e = lc.end(); b != e; b++)
+			{
+				auto &p = *b;
+				VERIFY(i == p.first);
+				VERIFY(i + 10 == p.second.first);
+				i++;
+			}
+		}
+
+		{ // test pairs 
+			int i = 0;
+			for(auto& p : lc)
+			{
+				VERIFY(i == p.first);
+				VERIFY(i + 10 == p.second.first);
+				i++;
+			}
+		}
+
+		{ // test structured bindings
+			int i = 0;
+			for(auto& [key, value] : lc)
+			{
+				VERIFY(i == key);
+				VERIFY(i + 10 == value.first);
+				i++;
+			}
+		}
+	}
+
+	// test initializer_list
+	{
+		eastl::lru_cache<int, int> lc = {{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}, {5, 15}};
+
+		int i = 0;
+		for(auto& p : lc)
+		{
+			VERIFY(i == p.first);
+			VERIFY(i + 10 == p.second.first);
+			i++;
+		}
+	}
+
 	return nErrorCount;
 }


### PR DESCRIPTION
EASTL: lru_cache iteration tests and added support for initializer_lists

eastl::atomic<T> : fixed msvc compiler warning 4459