### PR TITLE
Fixed warnings in function_detail.h on MSVC at warning level 4.

### DIFF
--- a/include/EASTL/internal/function_detail.h
+++ b/include/EASTL/internal/function_detail.h
@@ -649,7 +649,7 @@ namespace eastl
 			// We cannot assume that R is default constructible.
 			// This function is called only when the function object CANNOT be called because it is empty,
 			// it will always throw or assert so we never use the return value anyways and neither should the caller.
-			static R DefaultInvoker(Args... args, const FunctorStorageType& functor)
+			static R DefaultInvoker(Args..., const FunctorStorageType&)
 			{
 				#if EASTL_EXCEPTIONS_ENABLED
 					throw eastl::bad_function_call();


### PR DESCRIPTION
Fixed warning C4100: 'functor': unreferenced formal parameter and warning C4100: '<args_0>': unreferenced formal parameter on MSVC with warning level 4.