### PR TITLE
Using of qualified eastl move() and forward() functions.

### DIFF
--- a/include/EASTL/internal/hashtable.h
+++ b/include/EASTL/internal/hashtable.h
@@ -2702,7 +2702,7 @@ namespace eastl
 	hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::try_emplace(const key_type& key, Args&&... args)
 	{
 		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(key),
-		                     forward_as_tuple(forward<Args>(args)...));
+		                     forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename A, typename EK, typename Eq,
@@ -2713,7 +2713,7 @@ namespace eastl
 	hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::try_emplace(key_type&& key, Args&&... args)
 	{
 		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(eastl::move(key)),
-		                     forward_as_tuple(forward<Args>(args)...));
+		                     forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename A, typename EK, typename Eq,
@@ -2724,7 +2724,7 @@ namespace eastl
 	{
 		insert_return_type result = DoInsertValue(
 		    has_unique_keys_type(),
-		    value_type(piecewise_construct, forward_as_tuple(key), forward_as_tuple(forward<Args>(args)...)));
+		    value_type(piecewise_construct, forward_as_tuple(key), forward_as_tuple(eastl::forward<Args>(args)...)));
 
 		return DoGetResultIterator(has_unique_keys_type(), result);
 	}
@@ -2737,7 +2737,7 @@ namespace eastl
 	{
 		insert_return_type result =
 		    DoInsertValue(has_unique_keys_type(), value_type(piecewise_construct, forward_as_tuple(eastl::move(key)),
-		                                                     forward_as_tuple(forward<Args>(args)...)));
+		                                                     forward_as_tuple(eastl::forward<Args>(args)...)));
 
 		return DoGetResultIterator(has_unique_keys_type(), result);
 	}

--- a/include/EASTL/internal/red_black_tree.h
+++ b/include/EASTL/internal/red_black_tree.h
@@ -1105,7 +1105,7 @@ namespace eastl
 	inline eastl::pair<typename rbtree<K, V, C, A, E, bM, bU>::iterator, bool>
 	rbtree<K, V, C, A, E, bM, bU>::try_emplace(const key_type& key, Args&&... args)
 	{
-		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(key), forward_as_tuple(forward<Args>(args)...));
+		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(key), forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename C, typename A, typename E, bool bM, bool bU>
@@ -1113,7 +1113,7 @@ namespace eastl
 	inline eastl::pair<typename rbtree<K, V, C, A, E, bM, bU>::iterator, bool>
 	rbtree<K, V, C, A, E, bM, bU>::try_emplace(key_type&& key, Args&&... args)
 	{
-		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(eastl::move(key)), forward_as_tuple(forward<Args>(args)...));
+		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(eastl::move(key)), forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename C, typename A, typename E, bool bM, bool bU>
@@ -1123,7 +1123,7 @@ namespace eastl
 	{
 		return DoInsertValueHint(
 		    has_unique_keys_type(), position,
-		    piecewise_construct, forward_as_tuple(key), forward_as_tuple(forward<Args>(args)...));
+		    piecewise_construct, forward_as_tuple(key), forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename C, typename A, typename E, bool bM, bool bU>
@@ -1133,7 +1133,7 @@ namespace eastl
 	{
 		return DoInsertValueHint(
 		    has_unique_keys_type(), position,
-		    piecewise_construct, forward_as_tuple(eastl::move(key)), forward_as_tuple(forward<Args>(args)...));
+		    piecewise_construct, forward_as_tuple(eastl::move(key)), forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 

--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -789,7 +789,7 @@ namespace eastl
 			template <typename T1, typename T2>
 			static EA_CONSTEXPR T1&& getInternal(pair<T1, T2>&& p)
 			{
-				return forward<T1>(p.first);
+				return eastl::forward<T1>(p.first);
 			}
 		};
 
@@ -811,7 +811,7 @@ namespace eastl
 			template <typename T1, typename T2>
 			static EA_CONSTEXPR T2&& getInternal(pair<T1, T2>&& p)
 			{
-				return forward<T2>(p.second);
+				return eastl::forward<T2>(p.second);
 			}
 		};
 
@@ -830,7 +830,7 @@ namespace eastl
 		template <size_t I, typename T1, typename T2>
 		tuple_element_t<I, pair<T1, T2>>&& get(pair<T1, T2>&& p)
 		{
-			return GetPair<I>::getInternal(move(p));
+			return GetPair<I>::getInternal(eastl::move(p));
 		}
 
 #endif  // EASTL_TUPLE_ENABLED


### PR DESCRIPTION
This PR is similar to #333 in motive. In case of `std` types used as elements of some `eastl` containers, argument-dependent lookup result in `ambiguous call` errors for `move()` and `forward()` calls.

Small example: line `auto [str, flag] = eastl::pair<std::string, bool>("", false);` can't be compiled.