### PR TITLE
Fix get<T>(variant) when variant is a rvalue

### DIFF
--- a/include/EASTL/variant.h
+++ b/include/EASTL/variant.h
@@ -616,7 +616,7 @@ namespace eastl
 	EA_CONSTEXPR T&& get(variant<Types...>&& v)
 	{
 		static_assert(I < sizeof...(Types), "get is ill-formed if I is not a valid index in the variant typelist");
-		return get<I>(v);
+		return get<I>(eastl::move(v));
 	}
 
 	template <class T, class... Types, size_t I = meta::get_type_index_v<T, Types...>>

--- a/test/source/TestVariant.cpp
+++ b/test/source/TestVariant.cpp
@@ -212,6 +212,7 @@ int TestVariantGet()
 			VERIFY(get<string>(v) == strValue);
 			VERIFY(!holds_alternative<int>(v));
 			VERIFY(holds_alternative<string>(v));
+			VERIFY(get<string>(move(v)) == strValue);
 		}
 		{
 			v_t v;


### PR DESCRIPTION
Hello!
The function `eastl::get<T>(variant&&)` can't work because the `get<I>(v)` take a lvalue (*v* has a name so it is a lvalue) and so return a lvalue, which can't be implicitly converted to rvalue.
`eastl::move` is used to force *v* to be a rvalue.