### PR TITLE
Using of qualified eastl functions.

### DIFF
--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -2922,7 +2922,7 @@ namespace eastl
 		if(count <= 0)
 			return first;
 		else if(count == 1)
-			return find(first, last, value);
+			return eastl::find(first, last, value);
 		else if(last > first)
 		{
 			RandomAccessIterator lookAhead;
@@ -3758,7 +3758,7 @@ namespace eastl
 	{
 		typedef typename eastl::iterator_traits<BidirectionalIterator>::value_type value_type;
 
-		return next_permutation(first, last, eastl::less<value_type>());
+		return eastl::next_permutation(first, last, eastl::less<value_type>());
 	}
 
 
@@ -4061,12 +4061,6 @@ namespace eastl
 	///
 	/// http://en.cppreference.com/w/cpp/algorithm/clamp
 	///
-	template <class T>
-	EA_CONSTEXPR const T& clamp(const T& v, const T& lo, const T& hi)
-	{
-		return clamp(v, lo, hi, eastl::less<>());
-	}
-
 	template <class T, class Compare>
 	EA_CONSTEXPR const T& clamp(const T& v, const T& lo, const T& hi, Compare comp)
 	{
@@ -4075,6 +4069,11 @@ namespace eastl
 			   comp(v, lo) ? lo : comp(hi, v) ? hi : v;
 	}
 
+	template <class T>
+	EA_CONSTEXPR const T& clamp(const T& v, const T& lo, const T& hi)
+	{
+		return eastl::clamp(v, lo, hi, eastl::less<>());
+	}
 
 } // namespace eastl
 

--- a/include/EASTL/bonus/adaptors.h
+++ b/include/EASTL/bonus/adaptors.h
@@ -60,15 +60,15 @@ namespace eastl
 	};
 
 	template <typename Container>
-	auto begin(const reverse_wrapper<Container>& w) -> decltype(rbegin(w.mContainer))
+	auto begin(const reverse_wrapper<Container>& w) -> decltype(eastl::rbegin(w.mContainer))
 	{
-		return rbegin(w.mContainer);
+		return eastl::rbegin(w.mContainer);
 	}
 
 	template <typename Container>
-	auto end(const reverse_wrapper<Container>& w) -> decltype(rend(w.mContainer))
+	auto end(const reverse_wrapper<Container>& w) -> decltype(eastl::rend(w.mContainer))
 	{
-		return rend(w.mContainer);
+		return eastl::rend(w.mContainer);
 	}
 
 	template <typename Container>

--- a/include/EASTL/bonus/tuple_vector.h
+++ b/include/EASTL/bonus/tuple_vector.h
@@ -728,7 +728,7 @@ public:
 		{
 			if (newNumElements > oldNumCapacity)
 			{
-				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
+				const size_type newCapacity = eastl::max(GetNewCapacity(oldNumCapacity), newNumElements);
 
 				void* ppNewLeaf[sizeof...(Ts)];
 				pair<void*, size_type> allocation =	TupleRecurser<Ts...>::template DoAllocate<allocator_type, 0, index_sequence_type, Ts...>(
@@ -774,7 +774,7 @@ public:
 		{
 			if (newNumElements > oldNumCapacity)
 			{
-				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
+				const size_type newCapacity = eastl::max(GetNewCapacity(oldNumCapacity), newNumElements);
 
 				void* ppNewLeaf[sizeof...(Ts)];
 				pair<void*, size_type> allocation = TupleRecurser<Ts...>::template DoAllocate<allocator_type, 0, index_sequence_type, Ts...>(
@@ -826,7 +826,7 @@ public:
 		{
 			if (newNumElements > oldNumCapacity)
 			{
-				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
+				const size_type newCapacity = eastl::max(GetNewCapacity(oldNumCapacity), newNumElements);
 
 				void* ppNewLeaf[sizeof...(Ts)];
 				pair<void*, size_type> allocation = TupleRecurser<Ts...>::template DoAllocate<allocator_type, 0, index_sequence_type, Ts...>(
@@ -880,7 +880,7 @@ public:
 		{
 			if (newNumElements > oldNumCapacity)
 			{
-				const size_type newCapacity = max(GetNewCapacity(oldNumCapacity), newNumElements);
+				const size_type newCapacity = eastl::max(GetNewCapacity(oldNumCapacity), newNumElements);
 
 				void* ppNewLeaf[sizeof...(Ts)];
 				pair<void*, size_type> allocation = TupleRecurser<Ts...>::template DoAllocate<allocator_type, 0, index_sequence_type, Ts...>(

--- a/include/EASTL/internal/functional_base.h
+++ b/include/EASTL/internal/functional_base.h
@@ -210,7 +210,7 @@ namespace eastl
 
 	template <typename T>
 	reference_wrapper<T>::reference_wrapper(T &v) EA_NOEXCEPT
-		: val(addressof(v))
+		: val(eastl::addressof(v))
 	{}
 
 	template <typename T>

--- a/include/EASTL/internal/hashtable.h
+++ b/include/EASTL/internal/hashtable.h
@@ -2701,8 +2701,8 @@ namespace eastl
 	inline typename hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::insert_return_type
 	hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::try_emplace(const key_type& key, Args&&... args)
 	{
-		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(key),
-		                     forward_as_tuple(eastl::forward<Args>(args)...));
+		return DoInsertValue(has_unique_keys_type(), piecewise_construct, eastl::forward_as_tuple(key),
+		                     eastl::forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename A, typename EK, typename Eq,
@@ -2712,8 +2712,8 @@ namespace eastl
 	inline typename hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::insert_return_type
 	hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::try_emplace(key_type&& key, Args&&... args)
 	{
-		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(eastl::move(key)),
-		                     forward_as_tuple(eastl::forward<Args>(args)...));
+		return DoInsertValue(has_unique_keys_type(), piecewise_construct, eastl::forward_as_tuple(eastl::move(key)),
+		                     eastl::forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename A, typename EK, typename Eq,
@@ -2724,7 +2724,7 @@ namespace eastl
 	{
 		insert_return_type result = DoInsertValue(
 		    has_unique_keys_type(),
-		    value_type(piecewise_construct, forward_as_tuple(key), forward_as_tuple(eastl::forward<Args>(args)...)));
+		    value_type(piecewise_construct, eastl::forward_as_tuple(key), eastl::forward_as_tuple(eastl::forward<Args>(args)...)));
 
 		return DoGetResultIterator(has_unique_keys_type(), result);
 	}
@@ -2736,8 +2736,8 @@ namespace eastl
 	hashtable<K, V, A, EK, Eq, H1, H2, H, RP, bC, bM, bU>::try_emplace(const_iterator, key_type&& key, Args&&... args)
 	{
 		insert_return_type result =
-		    DoInsertValue(has_unique_keys_type(), value_type(piecewise_construct, forward_as_tuple(eastl::move(key)),
-		                                                     forward_as_tuple(eastl::forward<Args>(args)...)));
+		    DoInsertValue(has_unique_keys_type(), value_type(piecewise_construct, eastl::forward_as_tuple(eastl::move(key)),
+		                                                     eastl::forward_as_tuple(eastl::forward<Args>(args)...)));
 
 		return DoGetResultIterator(has_unique_keys_type(), result);
 	}
@@ -2850,7 +2850,7 @@ namespace eastl
 		auto iter = find(k);
 		if(iter == end())
 		{
-			return insert(value_type(piecewise_construct, forward_as_tuple(k), forward_as_tuple(eastl::forward<M>(obj))));
+			return insert(value_type(piecewise_construct, eastl::forward_as_tuple(k), eastl::forward_as_tuple(eastl::forward<M>(obj))));
 		}
 		else
 		{
@@ -2868,7 +2868,7 @@ namespace eastl
 		auto iter = find(k);
 		if(iter == end())
 		{
-			return insert(value_type(piecewise_construct, forward_as_tuple(eastl::move(k)), forward_as_tuple(eastl::forward<M>(obj))));
+			return insert(value_type(piecewise_construct, eastl::forward_as_tuple(eastl::move(k)), eastl::forward_as_tuple(eastl::forward<M>(obj))));
 		}
 		else
 		{

--- a/include/EASTL/internal/red_black_tree.h
+++ b/include/EASTL/internal/red_black_tree.h
@@ -1105,7 +1105,7 @@ namespace eastl
 	inline eastl::pair<typename rbtree<K, V, C, A, E, bM, bU>::iterator, bool>
 	rbtree<K, V, C, A, E, bM, bU>::try_emplace(const key_type& key, Args&&... args)
 	{
-		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(key), forward_as_tuple(eastl::forward<Args>(args)...));
+		return DoInsertValue(has_unique_keys_type(), piecewise_construct, eastl::forward_as_tuple(key), eastl::forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename C, typename A, typename E, bool bM, bool bU>
@@ -1113,7 +1113,7 @@ namespace eastl
 	inline eastl::pair<typename rbtree<K, V, C, A, E, bM, bU>::iterator, bool>
 	rbtree<K, V, C, A, E, bM, bU>::try_emplace(key_type&& key, Args&&... args)
 	{
-		return DoInsertValue(has_unique_keys_type(), piecewise_construct, forward_as_tuple(eastl::move(key)), forward_as_tuple(eastl::forward<Args>(args)...));
+		return DoInsertValue(has_unique_keys_type(), piecewise_construct, eastl::forward_as_tuple(eastl::move(key)), eastl::forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename C, typename A, typename E, bool bM, bool bU>
@@ -1123,7 +1123,7 @@ namespace eastl
 	{
 		return DoInsertValueHint(
 		    has_unique_keys_type(), position,
-		    piecewise_construct, forward_as_tuple(key), forward_as_tuple(eastl::forward<Args>(args)...));
+		    piecewise_construct, eastl::forward_as_tuple(key), eastl::forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 	template <typename K, typename V, typename C, typename A, typename E, bool bM, bool bU>
@@ -1133,7 +1133,7 @@ namespace eastl
 	{
 		return DoInsertValueHint(
 		    has_unique_keys_type(), position,
-		    piecewise_construct, forward_as_tuple(eastl::move(key)), forward_as_tuple(eastl::forward<Args>(args)...));
+		    piecewise_construct, eastl::forward_as_tuple(eastl::move(key)), eastl::forward_as_tuple(eastl::forward<Args>(args)...));
 	}
 
 
@@ -1180,7 +1180,7 @@ namespace eastl
 
 		if(iter == end())
 		{
-			return insert(value_type(piecewise_construct, forward_as_tuple(k), forward_as_tuple(eastl::forward<M>(obj))));
+			return insert(value_type(piecewise_construct, eastl::forward_as_tuple(k), eastl::forward_as_tuple(eastl::forward<M>(obj))));
 		}
 		else
 		{
@@ -1198,7 +1198,7 @@ namespace eastl
 
 		if(iter == end())
 		{
-			return insert(value_type(piecewise_construct, forward_as_tuple(eastl::move(k)), forward_as_tuple(eastl::forward<M>(obj))));
+			return insert(value_type(piecewise_construct, eastl::forward_as_tuple(eastl::move(k)), eastl::forward_as_tuple(eastl::forward<M>(obj))));
 		}
 		else
 		{
@@ -1216,7 +1216,7 @@ namespace eastl
 
 		if(iter == end())
 		{
-			return insert(hint, value_type(piecewise_construct, forward_as_tuple(k), forward_as_tuple(eastl::forward<M>(obj))));
+			return insert(hint, value_type(piecewise_construct, eastl::forward_as_tuple(k), eastl::forward_as_tuple(eastl::forward<M>(obj))));
 		}
 		else
 		{
@@ -1234,7 +1234,7 @@ namespace eastl
 
 		if(iter == end())
 		{
-			return insert(hint, value_type(piecewise_construct, forward_as_tuple(eastl::move(k)), forward_as_tuple(eastl::forward<M>(obj))));
+			return insert(hint, value_type(piecewise_construct, eastl::forward_as_tuple(eastl::move(k)), eastl::forward_as_tuple(eastl::forward<M>(obj))));
 		}
 		else
 		{

--- a/include/EASTL/memory.h
+++ b/include/EASTL/memory.h
@@ -1390,7 +1390,7 @@ namespace eastl
 	inline void destroy(ForwardIterator first, ForwardIterator last)
 	{
 		for (; first != last; ++first)
-			destroy_at(addressof(*first));
+			eastl::destroy_at(eastl::addressof(*first));
 	}
 
 
@@ -1404,7 +1404,7 @@ namespace eastl
 	ForwardIterator destroy_n(ForwardIterator first, Size n)
 	{
 		for (; n > 0; ++first, --n)
-			destroy_at(addressof(*first));
+			eastl::destroy_at(eastl::addressof(*first));
 
 		return first;
 	}

--- a/include/EASTL/optional.h
+++ b/include/EASTL/optional.h
@@ -111,7 +111,7 @@ namespace eastl
 			inline explicit optional_storage(in_place_t, Args&&... args)
 			    : engaged(true)
 			{
-				::new (eastl::addressof(val)) T{std::forward<Args>(args)...};
+				::new (eastl::addressof(val)) T{eastl::forward<Args>(args)...};
 			}
 
 			template <typename U,

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -439,7 +439,7 @@ namespace eastl
 
 			if (lastSortedEnd < 1)
 			{
-				lastSortedEnd = is_sorted_until<RandomAccessIterator, StrictWeakOrdering>(first, last, compare) - first;
+				lastSortedEnd = eastl::is_sorted_until<RandomAccessIterator, StrictWeakOrdering>(first, last, compare) - first;
 			}
 
 			// Sort the region unless lastSortedEnd indicates it is already sorted.

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -199,11 +199,11 @@ namespace Internal
 
 		// We shouldn't need this explicit constructor as it should be handled by the template below but OSX clang
 		// is_constructible type trait incorrectly gives false for is_constructible<T&&, T&&>::value
-		explicit TupleLeaf(ValueType&& v) : mValue(move(v)) {}
+		explicit TupleLeaf(ValueType&& v) : mValue(eastl::move(v)) {}
 
 		template <typename T, typename = typename enable_if<is_constructible<ValueType, T&&>::value>::type>
 		explicit TupleLeaf(T&& t)
-			: mValue(forward<T>(t))
+			: mValue(eastl::forward<T>(t))
 		{
 		}
 
@@ -216,7 +216,7 @@ namespace Internal
 		template <typename T>
 		TupleLeaf& operator=(T&& t)
 		{
-			mValue = forward<T>(t);
+			mValue = eastl::forward<T>(t);
 			return *this;
 		}
 
@@ -243,7 +243,7 @@ namespace Internal
 
 		template <typename T, typename = typename enable_if<is_constructible<ValueType, T&&>::value>::type>
 		explicit TupleLeaf(T&& t)
-			: mValue(forward<T>(t))
+			: mValue(eastl::forward<T>(t))
 		{
 		}
 
@@ -260,7 +260,7 @@ namespace Internal
 		template <typename T>
 		TupleLeaf& operator=(T&& t)
 		{
-			mValue = forward<T>(t);
+			mValue = eastl::forward<T>(t);
 			return *this;
 		}
 
@@ -288,7 +288,7 @@ namespace Internal
 
 		template <typename T, typename = typename enable_if<is_constructible<ValueType, T&&>::value>::type>
 		explicit TupleLeaf(T&& t)
-			: ValueType(forward<T>(t))
+			: ValueType(eastl::forward<T>(t))
 		{
 		}
 
@@ -301,7 +301,7 @@ namespace Internal
 		template <typename T>
 		TupleLeaf& operator=(T&& t)
 		{
-			ValueType::operator=(forward<T>(t));
+			ValueType::operator=(eastl::forward<T>(t));
 			return *this;
 		}
 
@@ -381,13 +381,13 @@ namespace Internal
 		// 
 		template <typename... Us, typename... ValueTypes>
 		explicit TupleImpl(integer_sequence<size_t, Indices...>, TupleTypes<Us...>, ValueTypes&&... values)
-			: TupleLeaf<Indices, Ts>(forward<ValueTypes>(values))...
+			: TupleLeaf<Indices, Ts>(eastl::forward<ValueTypes>(values))...
 		{
 		}
 
 		template <typename OtherTuple>
 		TupleImpl(OtherTuple&& t)
-			: TupleLeaf<Indices, Ts>(forward<tuple_element_t<Indices, MakeTupleTypes_t<OtherTuple>>>(get<Indices>(t)))...
+			: TupleLeaf<Indices, Ts>(eastl::forward<tuple_element_t<Indices, MakeTupleTypes_t<OtherTuple>>>(get<Indices>(t)))...
 		{
 		}
 
@@ -395,7 +395,7 @@ namespace Internal
 		TupleImpl& operator=(OtherTuple&& t)
 		{
 			swallow(TupleLeaf<Indices, Ts>::operator=(
-				forward<tuple_element_t<Indices, MakeTupleTypes_t<OtherTuple>>>(get<Indices>(t)))...);
+				eastl::forward<tuple_element_t<Indices, MakeTupleTypes_t<OtherTuple>>>(get<Indices>(t)))...);
 			return *this;
 		}
 
@@ -664,7 +664,7 @@ namespace Internal
 		template <typename Tuple1, typename Tuple2>
 		static inline ResultType DoCat2(Tuple1&& t1, Tuple2&& t2)
 		{
-			return ResultType(get<I1s>(forward<Tuple1>(t1))..., get<I2s>(forward<Tuple2>(t2))...);
+			return ResultType(get<I1s>(eastl::forward<Tuple1>(t1))..., get<I2s>(eastl::forward<Tuple2>(t2))...);
 		}
 	};
 
@@ -683,7 +683,7 @@ namespace Internal
 		template <typename Tuple1, typename Tuple2>
 		static inline ResultType DoCat2(Tuple1&& t1, Tuple2&& t2)
 		{
-			return TCI::DoCat2(forward<Tuple1>(t1), forward<Tuple2>(t2));
+			return TCI::DoCat2(eastl::forward<Tuple1>(t1), eastl::forward<Tuple2>(t2));
 		}
 	};
 
@@ -701,8 +701,8 @@ namespace Internal
 		static inline ResultType DoCat(TupleArg1&& t1, TupleArg2&& t2, TupleArgsRest&&... ts)
 		{
 			return TupleCat<FirstResultType, TuplesRest...>::DoCat(
-				TupleCat2<TupleArg1, TupleArg2>::DoCat2(forward<TupleArg1>(t1), forward<TupleArg2>(t2)),
-				forward<TupleArgsRest>(ts)...);
+				TupleCat2<TupleArg1, TupleArg2>::DoCat2(eastl::forward<TupleArg1>(t1), eastl::forward<TupleArg2>(t2)),
+				eastl::forward<TupleArgsRest>(ts)...);
 		}
 	};
 
@@ -715,7 +715,7 @@ namespace Internal
 		template <typename TupleArg1, typename TupleArg2>
 		static inline ResultType DoCat(TupleArg1&& t1, TupleArg2&& t2)
 		{
-			return TC2::DoCat2(forward<TupleArg1>(t1), forward<TupleArg2>(t2));
+			return TC2::DoCat2(eastl::forward<TupleArg1>(t1), eastl::forward<TupleArg2>(t2));
 		}
 	};
 }  // namespace Internal
@@ -755,23 +755,23 @@ public:
 	template <typename U, typename... Us,
 		Internal::TupleImplicitlyConvertible_t<tuple, U, Us...> = 0>
 		EA_CONSTEXPR tuple(U&& u, Us&&... us)
-		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, forward<U>(u),
-			forward<Us>(us)...)
+		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, eastl::forward<U>(u),
+			eastl::forward<Us>(us)...)
 	{
 	}
 
 	template <typename U, typename... Us,
 		Internal::TupleExplicitlyConvertible_t<tuple, U, Us...> = 0>
 		explicit EA_CONSTEXPR tuple(U&& u, Us&&... us)
-		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, forward<U>(u),
-			forward<Us>(us)...)
+		: mImpl(make_index_sequence<sizeof...(Us) + 1>{}, Internal::MakeTupleTypes_t<tuple>{}, eastl::forward<U>(u),
+			eastl::forward<Us>(us)...)
 	{
 	}
 
 	template <typename OtherTuple,
 			  typename enable_if<Internal::TupleConvertible<OtherTuple, tuple>::value, bool>::type = false>
 	tuple(OtherTuple&& t)
-		: mImpl(forward<OtherTuple>(t))
+		: mImpl(eastl::forward<OtherTuple>(t))
 	{
 	}
 
@@ -779,7 +779,7 @@ public:
 			  typename enable_if<Internal::TupleAssignable<tuple, OtherTuple>::value, bool>::type = false>
 	tuple& operator=(OtherTuple&& t)
 	{
-		mImpl.operator=(forward<OtherTuple>(t));
+		mImpl.operator=(eastl::forward<OtherTuple>(t));
 		return *this;
 	}
 
@@ -886,7 +886,7 @@ template <typename... T1s, typename... T2s> inline bool operator>=(const tuple<T
 template <typename... Tuples>
 inline typename Internal::TupleCat<Tuples...>::ResultType tuple_cat(Tuples&&... ts)
 {
-	return Internal::TupleCat<Tuples...>::DoCat(forward<Tuples>(ts)...);
+	return Internal::TupleCat<Tuples...>::DoCat(eastl::forward<Tuples>(ts)...);
 }
 
 
@@ -896,7 +896,7 @@ inline typename Internal::TupleCat<Tuples...>::ResultType tuple_cat(Tuples&&... 
 template <typename... Ts>
 inline EA_CONSTEXPR tuple<Internal::MakeTupleReturn_t<Ts>...> make_tuple(Ts&&... values)
 {
-	return tuple<Internal::MakeTupleReturn_t<Ts>...>(forward<Ts>(values)...);
+	return tuple<Internal::MakeTupleReturn_t<Ts>...>(eastl::forward<Ts>(values)...);
 }
 
 
@@ -906,7 +906,7 @@ inline EA_CONSTEXPR tuple<Internal::MakeTupleReturn_t<Ts>...> make_tuple(Ts&&...
 template <typename... Ts>
 inline EA_CONSTEXPR tuple<Ts&&...> forward_as_tuple(Ts&&... ts) EA_NOEXCEPT
 {
-	return tuple<Ts&&...>(forward<Ts&&>(ts)...);
+	return tuple<Ts&&...>(eastl::forward<Ts&&>(ts)...);
 }
 
 
@@ -957,14 +957,14 @@ namespace detail
 	template <class F, class Tuple, size_t... I>
 	EA_CONSTEXPR decltype(auto) apply_impl(F&& f, Tuple&& t, index_sequence<I...>)
 	{
-		return invoke(forward<F>(f), get<I>(forward<Tuple>(t))...);
+		return invoke(eastl::forward<F>(f), get<I>(eastl::forward<Tuple>(t))...);
 	}
 } // namespace detail
 
 template <class F, class Tuple>
 EA_CONSTEXPR decltype(auto) apply(F&& f, Tuple&& t)
 {
-	return detail::apply_impl(forward<F>(f), forward<Tuple>(t),
+	return detail::apply_impl(eastl::forward<F>(f), eastl::forward<Tuple>(t),
 		                      make_index_sequence<tuple_size_v<remove_reference_t<Tuple>>>{});
 }
 

--- a/include/EASTL/variant.h
+++ b/include/EASTL/variant.h
@@ -727,7 +727,7 @@ namespace eastl
 			class... Args,
 			class = enable_if_t<conjunction_v<meta::duplicate_type_check<T, Types...>, is_constructible<T, Args...>>, T>>
 		EA_CPP14_CONSTEXPR explicit variant(in_place_type_t<T>, Args&&... args)
-			: variant(in_place<meta::get_type_index_v<T, Types...>>, forward<Args>(args)...)
+			: variant(in_place<meta::get_type_index_v<T, Types...>>, eastl::forward<Args>(args)...)
 		{}
 
 		template <
@@ -736,7 +736,7 @@ namespace eastl
 		    class... Args,
 		    class = enable_if_t<conjunction_v<meta::duplicate_type_check<T, Types...>, is_constructible<T, Args...>>, T>>
 		EA_CPP14_CONSTEXPR explicit variant(in_place_type_t<T>, std::initializer_list<U> il, Args&&... args)
-		    : variant(in_place<meta::get_type_index_v<T, Types...>>, il, forward<Args>(args)...)
+		    : variant(in_place<meta::get_type_index_v<T, Types...>>, il, eastl::forward<Args>(args)...)
 		{}
 
 		template <size_t I,
@@ -746,7 +746,7 @@ namespace eastl
 		EA_CPP14_CONSTEXPR explicit variant(in_place_index_t<I>, Args&&... args)
 		    : mIndex(I)
 		{
-			mStorage.template set_as<meta::get_type_at_t<I, Types...>>(forward<Args>(args)...);
+			mStorage.template set_as<meta::get_type_at_t<I, Types...>>(eastl::forward<Args>(args)...);
 		}
 
 		template <size_t I,
@@ -757,7 +757,7 @@ namespace eastl
 		EA_CPP14_CONSTEXPR explicit variant(in_place_index_t<I>, std::initializer_list<U> il, Args&&... args)
 		    : mIndex(I)
 		{
-			mStorage.template set_as<meta::get_type_at_t<I, Types...>>(il, forward<Args>(args)...);
+			mStorage.template set_as<meta::get_type_at_t<I, Types...>>(il, eastl::forward<Args>(args)...);
 		}
 
 
@@ -984,11 +984,11 @@ namespace eastl
 			// all of the previous arguments. Then call the next visitor_caller with the new argument added,
 			// and the current variant removed.
 			return visitor_caller<Visitor, Variants...>::call(
-				forward<Visitor>(visitor),
+				eastl::forward<Visitor>(visitor),
 				index_sequence<ArgsIndices..., sizeof...(ArgsIndices)>(),
 				index_sequence<ArrayIndices...>(),
-				make_tuple(get<ArgsIndices>(forward<ArgsTuple>(args))..., get<I>(forward<Variant>(variant))),
-				forward<Variants>(variants)...
+				eastl::make_tuple(get<ArgsIndices>(eastl::forward<ArgsTuple>(args))..., get<I>(eastl::forward<Variant>(variant))),
+				eastl::forward<Variants>(variants)...
 			);
 		}
 
@@ -1003,12 +1003,12 @@ namespace eastl
 		{
 			// Deduce the type of the inner array of call_next functions
 			using return_type = decltype(call_next<0>(
-				forward<Visitor>(visitor),
+				eastl::forward<Visitor>(visitor),
 				index_sequence<ArgsIndices...>(),
 				index_sequence<ArrayIndices...>(),
-				forward<ArgsTuple>(args),
-				forward<Variant>(variant),
-				forward<Variants>(variants)...)
+				eastl::forward<ArgsTuple>(args),
+				eastl::forward<Variant>(variant),
+				eastl::forward<Variants>(variants)...)
 			);
 
 			using next_type = return_type (*)(
@@ -1026,12 +1026,12 @@ namespace eastl
 
 			// call_next() with the correct index for the variant.
 			return next[variant.index()](
-				forward<Visitor>(visitor),
+				eastl::forward<Visitor>(visitor),
 				index_sequence<ArgsIndices...>(),
 				index_sequence<ArrayIndices...>(),
-				forward<ArgsTuple>(args),
-				forward<Variant>(variant),
-				forward<Variants>(variants)...
+				eastl::forward<ArgsTuple>(args),
+				eastl::forward<Variant>(variant),
+				eastl::forward<Variants>(variants)...
 			);
 		}
 	};
@@ -1045,9 +1045,9 @@ namespace eastl
 		static decltype(auto) EA_CONSTEXPR invoke_visitor(Visitor&& visitor, index_sequence<ArgsIndices...>, ArgsTuple&& args, Variant&& variant)
 		{
 			return static_cast<R>(invoke(
-				forward<Visitor>(visitor),
-				get<ArgsIndices>(forward<ArgsTuple>(args))...,
-				get<I>(forward<Variant>(variant))
+				eastl::forward<Visitor>(visitor),
+				get<ArgsIndices>(eastl::forward<ArgsTuple>(args))...,
+				get<I>(eastl::forward<Variant>(variant))
 			));
 		}
 
@@ -1087,11 +1087,11 @@ namespace eastl
 			// where N = variant_size<Variant>
 			EA_CPP14_CONSTEXPR caller_type callers[] = { invoke_visitor<return_type, ArrayIndices>... };
 
-			return callers[forward<Variant>(variant).index()](
-				forward<Visitor>(visitor),
+			return callers[eastl::forward<Variant>(variant).index()](
+				eastl::forward<Visitor>(visitor),
 				index_sequence<ArgsIndices...>(),
-				forward<ArgsTuple>(args),
-				forward<Variant>(variant)
+				eastl::forward<ArgsTuple>(args),
+				eastl::forward<Variant>(variant)
 			);
 		}
 	};
@@ -1123,11 +1123,11 @@ namespace eastl
 		              "all variants passed to eastl::visit() must have the same type");
 
 		return visitor_caller<Visitor, Variants...>::call(
-			forward<Visitor>(visitor),
+			eastl::forward<Visitor>(visitor),
 			index_sequence<>(),
 			make_index_sequence<variant_size_v<variant_type>>(),
 			tuple<>(),
-			forward<Variants>(variants)...
+			eastl::forward<Variants>(variants)...
 		);
 	}
 


### PR DESCRIPTION
This PR makes calls to some eastl functions qualified. This helps to avoid ambiguity in a function calls caused by argument-dependent lookup.
Full list of functions affected by this PR:
```
clamp
max
find
next_permutation
is_sorted_until
rbegin
rend
addressof
destroy_at
move
forward
forward_as_tuple
```