### PR TITLE
Removed extra parentheses on eastl::move's return statement

### DIFF
--- a/include/EASTL/internal/move_help.h
+++ b/include/EASTL/internal/move_help.h
@@ -112,7 +112,7 @@ namespace eastl
 	EA_CPP14_CONSTEXPR typename eastl::remove_reference<T>::type&&
 	move(T&& x) EA_NOEXCEPT
 	{
-		return ((typename eastl::remove_reference<T>::type&&)x);
+		return static_cast<typename eastl::remove_reference<T>::type&&>(x);
 	}
 
 


### PR DESCRIPTION
This silences a specific clang-tidy check when using the pass-by-value + move idiom

```cpp
class Foo
{
public:
    Foo(eastl::string str)
        : m_str{ eastl::move(str) }
    {}

private:
    eastl::string m_str;
};
```
```
warning: the parameter 'str' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
        Foo(eastl::string str)
                          ^
            const        &
```

With the change introduced with this PR, this warning disappears.