### PR TITLE
Add workaround for MinGW bug.

### DIFF
--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -303,7 +303,12 @@ namespace eastl
 
 		// CtorSprintf exists so that we can create a constructor that accepts printf-style
 		// arguments but also doesn't collide with any other constructor declaration.
-		struct CtorSprintf{};
+		#ifdef EA_PLATFORM_MINGW
+			// Workaround for MinGW compiler bug: variadic arguments are corrupted if empty object is passed before it
+			struct CtorSprintf{ int dummy; };
+		#else
+			struct CtorSprintf{};
+		#endif
 
 		// CtorConvert exists so that we can have a constructor that implements string encoding
 		// conversion, such as between UCS2 char16_t and UTF8 char8_t.


### PR DESCRIPTION
Hello.

I think I found a bug in MinGW compiler, and EASTL could use a workaround for it.

MinGW cannot handle both zero-size object and variadic arguments
in function signature. If CtorSprintf is empty, variadic arguments of
corresponding string ctor become corrupted. As a result,
eastl::to_string returns random garbage with MinGW compiler.

The workaround is to add unused member into CtorSprintf.

I admit that I couldn't build EASTL tests with my current MinGW setup.
However, this bug was reproduced both on my machine and on machine of the user who reported this bug to me.

This bug reproduces in this example code (which is oversimplified version of string sprintf ctor):
```
#include <cstdio>
#include <cstdarg>

struct Tag1 {};
struct Tag2 { int m; };

void test1(Tag1, const char* pFormat, ...)
{
	va_list arguments;
	va_start(arguments, pFormat);
	vprintf(pFormat, arguments);
	va_end(arguments);
}

void test2(Tag2, const char* pFormat, ...)
{
	va_list arguments;
	va_start(arguments, pFormat);
	vprintf(pFormat, arguments);
	va_end(arguments);
}

int main()
{
	test1(Tag1{}, "Test1: %u\n", 128); // prints 0
	test2(Tag2{}, "Test2: %u\n", 128); // prints 128
	return 0;
}
```
![image](https://user-images.githubusercontent.com/8576192/105628064-a93f7b00-5e4b-11eb-86aa-8aac4fa5aa5e.png)
