### PR TITLE
Ability to default-construct tuple containing an empty type.

### DIFF
--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -284,6 +284,7 @@ namespace Internal
 	public:
 		// true_type / false_type constructors for case where ValueType is default constructible and should be value
 		// initialized and case where it is not
+		TupleLeaf() = default;
 		TupleLeaf(const TupleLeaf&) = default;
 
 		template <typename T, typename = typename enable_if<is_constructible<ValueType, T&&>::value>::type>

--- a/test/source/TestTuple.cpp
+++ b/test/source/TestTuple.cpp
@@ -524,6 +524,23 @@ int TestTuple()
 		static_assert(eastl::is_same_v<eastl::tuple_element_t<0, ResultTuple_t>, eastl::unique_ptr<int[]>>);
 	}
 
+	// support of empty types
+	{
+		static_assert(eastl::is_empty_v<eastl::true_type>);
+
+		static_assert(eastl::tuple_size_v<eastl::tuple<eastl::true_type>> == 1);
+		static_assert(eastl::tuple_size_v<eastl::tuple<int, eastl::true_type>> == 2);
+
+		// check empty base class optimization
+		static_assert(sizeof(eastl::tuple<int>) == sizeof(eastl::tuple<int, eastl::true_type>));
+		
+		// check costruction
+		static_assert(eastl::is_default_constructible_v<eastl::true_type>);
+		static_assert(eastl::is_default_constructible_v<eastl::tuple<eastl::true_type>>);
+		static_assert(eastl::is_constructible_v<eastl::tuple<eastl::true_type>, eastl::true_type>);
+		static_assert(eastl::is_same_v<decltype(eastl::make_tuple(eastl::true_type())), eastl::tuple<eastl::true_type>>);
+	}
+
 	return nErrorCount;
 }
 


### PR DESCRIPTION
Currently, attempt to default-construct tuple with an empty type results in a compiler error. Reason is in specialization of internal helper class `TupleLeaf` which implicitly deletes default constructor in case of `is_empty_v<ValueType>`.