### PR TITLE
Add assertion failure variant for win kernel

### DIFF
--- a/source/assert.cpp
+++ b/source/assert.cpp
@@ -7,7 +7,9 @@
 #include <EASTL/string.h>
 #include <EABase/eabase.h>
 
-#if defined(EA_PLATFORM_MICROSOFT)
+#if defined(EA_PLATFORM_WINDOWS_KERNEL)
+	#include <Wdm.h>
+#elif defined(EA_PLATFORM_MICROSOFT)
 	EA_DISABLE_ALL_VC_WARNINGS();
 	#if defined(EA_COMPILER_MSVC)
 		#include <crtdbg.h>
@@ -62,7 +64,9 @@ namespace eastl
 	EASTL_API void AssertionFailureFunctionDefault(const char* pExpression, void* /*pContext*/)
 	{
 		#if EASTL_ASSERT_ENABLED
-			#if defined(EA_PLATFORM_MICROSOFT)
+			#if defined(EA_PLATFORM_WINDOWS_KERNEL)
+				DbgPrintEx(DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "%s", pExpression);
+			#elif defined(EA_PLATFORM_MICROSOFT)
 				printf("%s\n", pExpression); // Write the message to stdout
 				if( ::IsDebuggerPresent())
 				{


### PR DESCRIPTION
Like some others (#118, #387), I am using EASTL in Windows kernel mode. Some of the default source files such as `assert.cpp` do not compile/work in this context because they require user-mode Windows functions. This PR removes this dependency from `assert.cpp` and provides a default variant for assertion failure in kernel mode.

This needs electronicarts/EABase#4 as prerequisite.