### PR TITLE
Fixing stack-use-after-scope ASan error detected in the [Allocator] test

### DIFF
--- a/test/source/TestAllocator.cpp
+++ b/test/source/TestAllocator.cpp
@@ -129,7 +129,6 @@ static int TestFixedAllocator()
 		typedef eastl::list<int, fixed_allocator_with_overflow> IntList;
 		typedef IntList::node_type IntListNode;
 
-		IntList intList1;
 		const size_t kAlignOfIntListNode = EA_ALIGN_OF(IntListNode);
 
 		// ensure the fixed buffer contains the default value that will be replaced
@@ -139,6 +138,8 @@ static int TestFixedAllocator()
 			buffer1[i].mValue = DEFAULT_VALUE;
 			EATEST_VERIFY(buffer1[i].mValue == DEFAULT_VALUE);
 		}
+
+		IntList intList1;
 
 		// replace all the values in the local buffer with the test value
 		intList1.get_allocator().init(buffer1, sizeof(buffer1), sizeof(IntListNode), kAlignOfIntListNode);


### PR DESCRIPTION
Running MSVC's ASan on EASTL's test suite discovered a stack-use-after-scope error due to an incorrect order of construction for certain stack variables. A reference to `buffer1` is used by `intList1`, but `buffer1`'s lifetime is shorter than that of `intList1` because variables are destroyed in reverse order of destruction. The fix is to move the construction of `intList1` after that of `buffer1` to make sure `buffer1` outlives `intList1`.