### PR TITLE
Fixing heap-buffer-overflow error uncovered by ASan in the [Sort] test.

### DIFF
--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -305,7 +305,7 @@ namespace eastl
 					{
 						iBack = iCurrent = iSorted;
 						
-						for(iBack -= nSpace; (iCurrent != iInsertFirst) && compare(*iCurrent, *iBack); iCurrent = iBack, iBack -= nSpace)
+						for(; (iCurrent != iInsertFirst) && compare(*iCurrent, *(iBack -= nSpace)); iCurrent = iBack)
 						{
 							EASTL_VALIDATE_COMPARE(!compare(*iBack, *iCurrent)); // Validate that the compare function is sane.
 							eastl::iter_swap(iCurrent, iBack);


### PR DESCRIPTION
A bug in the shell_sort algorithm causes a random access iterator to be decremented past begin. Depending on which data structure the iterator points to, decrementing it can trigger memory accesses that are only valid when the iterator is within the correct range. An example of such a data structure is EASTL's deque. This change fixes the algorithm to only decrement the random access iterator when it is valid to do so.