### PR TITLE
Fix undefined behavior in memory.h

### DIFF
--- a/include/EASTL/memory.h
+++ b/include/EASTL/memory.h
@@ -439,6 +439,9 @@ namespace eastl
 			template <typename T>
 			static T* do_move_start(T* first, T* last, T* dest)
 			{
+				if (EASTL_UNLIKELY(first == last))
+					return dest;
+
 				return (T*)memcpy(dest, first, (size_t)((uintptr_t)last - (uintptr_t)first)) + (last - first);
 			}
 
@@ -882,6 +885,9 @@ namespace eastl
 		template <typename ForwardIterator, typename Count>
 		inline void uninitialized_default_fill_n_impl(ForwardIterator first, Count n, true_type)
 		{
+			if (EASTL_UNLIKELY(n == 0))
+				return;
+
 			typedef typename eastl::iterator_traits<ForwardIterator>::value_type value_type;
 			memset(first, 0, sizeof(value_type) * n);
 		}


### PR DESCRIPTION
This is a fix for crashes in optimized builds by GCC.

Literally the same bug and the same fix as in #280, just in two more functions