### PR TITLE
Add lost install commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,3 +52,8 @@ endif()
 
 target_link_libraries(EASTL EABase)
 
+#-------------------------------------------------------------------------------------------
+# Installation
+#-------------------------------------------------------------------------------------------
+install(TARGETS EASTL DESTINATION lib)
+install(DIRECTORY include/EASTL DESTINATION include)

--- a/include/EASTL/internal/type_compound.h
+++ b/include/EASTL/internal/type_compound.h
@@ -79,7 +79,7 @@ namespace eastl
 	template<typename T, size_t N>
 	struct is_array<T[N]> : public eastl::true_type {};
 
-	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
+	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template<typename T>
 		EA_CONSTEXPR bool is_array_v = is_array<T>::value;
 	#endif
@@ -257,7 +257,7 @@ namespace eastl
 	template <typename T> 
 	struct is_pointer : public integral_constant<bool, is_pointer_value<T>::value>{};
 
-	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
+	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template<typename T>
 		EA_CONSTEXPR bool is_pointer_v = is_pointer<T>::value;
 	#endif
@@ -329,7 +329,7 @@ namespace eastl
 
 	#endif
 
-	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
+	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template<typename From, typename To>
 		EA_CONSTEXPR bool is_convertible_v = is_convertible<From, To>::value;
 	#endif

--- a/include/EASTL/internal/type_fundamental.h
+++ b/include/EASTL/internal/type_fundamental.h
@@ -232,7 +232,7 @@ namespace eastl
 
 	template <typename T>
 	struct is_fundamental
-		: public bool_constant<is_void_v<T> || is_integral_v<T> || is_floating_point_v<T> || is_null_pointer_v<T>> {};
+		: public bool_constant<is_void<T>::value || is_integral<T>::value || is_floating_point<T>::value || is_null_pointer<T>::value> {};
 
 	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template<typename T>

--- a/include/EASTL/internal/type_properties.h
+++ b/include/EASTL/internal/type_properties.h
@@ -70,7 +70,7 @@ namespace eastl
 
 		template <typename T>
 		struct has_unique_object_representations
-			: public integral_constant<bool, is_integral_v<remove_cv_t<remove_all_extents_t<T>>>> // only integral types (floating point types excluded).
+			: public integral_constant<bool, is_integral<remove_cv_t<remove_all_extents_t<T>>>::value> // only integral types (floating point types excluded).
 		{
 		};
 

--- a/include/EASTL/internal/type_transformations.h
+++ b/include/EASTL/internal/type_transformations.h
@@ -157,7 +157,7 @@ namespace eastl
 		#endif
 	#endif
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <class T>
 		using make_signed_t = typename make_signed<T>::type;
 	#endif
@@ -227,7 +227,7 @@ namespace eastl
 		#endif
 	#endif
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <class T>
 		using make_unsigned_t = typename make_unsigned<T>::type;
 	#endif
@@ -273,7 +273,7 @@ namespace eastl
 	template<typename T> struct remove_pointer<T* volatile>       { typedef T type; };
 	template<typename T> struct remove_pointer<T* const volatile> { typedef T type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <class T>
 		using remove_pointer_t = typename remove_pointer<T>::type;
     #endif
@@ -293,7 +293,7 @@ namespace eastl
 	template<class T>
 	struct add_pointer { typedef typename eastl::remove_reference<T>::type* type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <class T>
 		using add_pointer_t = typename add_pointer<T>::type;
     #endif
@@ -573,7 +573,7 @@ namespace eastl
 	//                                 decltype(declval<T>().end())>> : true_type {};
 	//
 	///////////////////////////////////////////////////////////////////////
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <class...>
 		using void_t = void;
 	#endif

--- a/include/EASTL/type_traits.h
+++ b/include/EASTL/type_traits.h
@@ -350,7 +350,7 @@ namespace eastl
 	template <typename ConditionIsTrueType, class ConditionIsFalseType>
 	struct type_select<false, ConditionIsTrueType, ConditionIsFalseType> { typedef ConditionIsFalseType type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <bool bCondition, class ConditionIsTrueType, class ConditionIsFalseType>
 		using type_select_t = typename type_select<bCondition, ConditionIsTrueType, ConditionIsFalseType>::type;
 	#endif
@@ -444,7 +444,7 @@ namespace eastl
 	template <typename T>
 	struct enable_if<true, T> { typedef T type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <bool B, class T = void>
 		using enable_if_t = typename enable_if<B, T>::type;
 	#endif
@@ -456,7 +456,7 @@ namespace eastl
 	template <typename T>
 	struct disable_if<false, T> { typedef T type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <bool B, class T = void>
 		using disable_if_t = typename disable_if<B, T>::type;
 	#endif
@@ -475,7 +475,7 @@ namespace eastl
 	template <typename T, typename F>
 	struct conditional<false, T, F> { typedef F type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <bool B, class T, class F>
 		using conditional_t = typename conditional<B, T, F>::type;
 	#endif
@@ -580,7 +580,7 @@ namespace eastl
 	template <typename T>
 	struct identity { using type = T; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <typename T>
 		using identity_t = typename identity<T>::type;
 	#endif
@@ -598,7 +598,7 @@ namespace eastl
 	template <typename T>
 	struct type_identity { using type = T; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template <typename T>
 		using type_identity_t = typename type_identity<T>::type;
 	#endif
@@ -765,7 +765,7 @@ namespace eastl
 	template <typename T>           struct remove_const<const T[]>  { typedef T type[];  };
 	template <typename T, size_t N> struct remove_const<const T[N]> { typedef T type[N]; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template<typename T>
 		using remove_const_t = typename remove_const<T>::type;
 	#endif
@@ -792,7 +792,7 @@ namespace eastl
 	template <typename T>           struct remove_volatile<volatile T[]>  { typedef T type[];  };
 	template <typename T, size_t N> struct remove_volatile<volatile T[N]> { typedef T type[N]; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template<typename T>
 		using remove_volatile_t = typename remove_volatile<T>::type;
 	#endif
@@ -817,7 +817,7 @@ namespace eastl
 	template <typename T>
 	struct remove_cv { typedef typename eastl::remove_volatile<typename eastl::remove_const<T>::type>::type type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template<typename T>
 		using remove_cv_t = typename remove_cv<T>::type;
 	#endif
@@ -866,7 +866,7 @@ namespace eastl
 	template <typename T> struct remove_reference<T&> { typedef T type; };
 	template <typename T> struct remove_reference<T&&>{ typedef T type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template<typename T>
 		using remove_reference_t = typename remove_reference<T>::type;
 	#endif
@@ -889,7 +889,7 @@ namespace eastl
 	template <typename T>
 	struct remove_cvref { typedef typename eastl::remove_volatile<typename eastl::remove_const<typename eastl::remove_reference<T>::type>::type>::type type; };
 
-	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+	#if !defined(EA_COMPILER_NO_TEMPLATE_ALIASES)
 		template<typename T>
 		using remove_cvref_t = typename remove_cvref<T>::type;
 	#endif


### PR DESCRIPTION
Not having an install target makes it difficult to use EASTL in an automatic build setup. These two lines of code were removed from EASTL in 376bcdc93502208b3e61b88c911fad0f9c9e3f60. This is not by any means new code. Since this, then, clearly is the work of others (and not my own) I cannot in good confidence sign the EA CLA.

This should be merged after https://github.com/electronicarts/EABase/pull/5.