### PR TITLE
Replaced some generic calls to operator< by eastl::less

### DIFF
--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -806,18 +806,18 @@ namespace eastl
 	template <typename T>
 	inline T&& median_impl(T&& a, T&& b, T&& c)
 	{
-		if(a < b)
+		if(eastl::less<T>()(a, b))
 		{
-			if(b < c)
+			if(eastl::less<T>()(b, c))
 				return eastl::forward<T>(b);
-			else if(a < c)
+			else if(eastl::less<T>()(a, c))
 				return eastl::forward<T>(c);
 			else
 				return eastl::forward<T>(a);
 		}
-		else if(a < c)
+		else if(eastl::less<T>()(a, c))
 			return eastl::forward<T>(a);
-		else if(b < c)
+		else if(eastl::less<T>()(b, c))
 			return eastl::forward<T>(c);
 		return eastl::forward<T>(b);
 	}

--- a/include/EASTL/heap.h
+++ b/include/EASTL/heap.h
@@ -55,7 +55,7 @@ namespace eastl
 	inline void promote_heap_impl(RandomAccessIterator first, Distance topPosition, Distance position, T value)
 	{
 		for(Distance parentPosition = (position - 1) >> 1; // This formula assumes that (position > 0). // We use '>> 1' instead of '/ 2' because we have seen VC++ generate better code with >>.
-			(position > topPosition) && (*(first + parentPosition) < value);
+			(position > topPosition) && eastl::less<ValueType>()(*(first + parentPosition), value);
 			parentPosition = (position - 1) >> 1)
 		{
 			*(first + position) = eastl::forward<ValueType>(*(first + parentPosition)); // Swap the node with its parent.
@@ -170,7 +170,7 @@ namespace eastl
 
 		for(; childPosition < heapSize; childPosition = (2 * childPosition) + 2)
 		{
-			if(*(first + childPosition) < *(first + (childPosition - 1))) // Choose the larger of the two children.
+			if(eastl::less<ValueType>()(*(first + childPosition), *(first + (childPosition - 1)))) // Choose the larger of the two children.
 				--childPosition;
 			*(first + position) = eastl::forward<ValueType>(*(first + childPosition)); // Swap positions with this child.
 			position = childPosition;

--- a/include/EASTL/sort.h
+++ b/include/EASTL/sort.h
@@ -715,18 +715,20 @@ namespace eastl
 	template <typename RandomAccessIterator, typename T>
 	inline RandomAccessIterator get_partition_impl(RandomAccessIterator first, RandomAccessIterator last, T&& pivotValue)
 	{
+		using PureT = decay_t<T>;
+
 		for(; ; ++first)
 		{
-			while(*first < pivotValue)
+			while(eastl::less<PureT>()(*first, pivotValue))
 			{
-				EASTL_VALIDATE_COMPARE(!(pivotValue < *first)); // Validate that the compare function is sane.
+				EASTL_VALIDATE_COMPARE(!eastl::less<PureT>()(pivotValue, *first)); // Validate that the compare function is sane.
 				++first;
 			}
 			--last;
 
-			while(pivotValue < *last)
+			while(eastl::less<PureT>()(pivotValue, *last))
 			{
-				EASTL_VALIDATE_COMPARE(!(*last < pivotValue)); // Validate that the compare function is sane.
+				EASTL_VALIDATE_COMPARE(!eastl::less<PureT>()(*last, pivotValue)); // Validate that the compare function is sane.
 				--last;
 			}
 
@@ -813,9 +815,9 @@ namespace eastl
 				RandomAccessIterator end(current), prev(current);
 				value_type           value(eastl::forward<value_type>(*current));
 
-				for(--prev; value < *prev; --end, --prev) // We skip checking for (prev >= first) because quick_sort (our caller) makes this unnecessary.
+				for(--prev; eastl::less<value_type>()(value, *prev); --end, --prev) // We skip checking for (prev >= first) because quick_sort (our caller) makes this unnecessary.
 				{
-					EASTL_VALIDATE_COMPARE(!(*prev < value)); // Validate that the compare function is sane.
+					EASTL_VALIDATE_COMPARE(!eastl::less<value_type>()(*prev, value)); // Validate that the compare function is sane.
 					*end = eastl::forward<value_type>(*prev);
 				}
 
@@ -860,9 +862,9 @@ namespace eastl
 
 		for(RandomAccessIterator i = middle; i < last; ++i)
 		{
-			if(*i < *first)
+			if(eastl::less<value_type>()(*i, *first))
 			{
-				EASTL_VALIDATE_COMPARE(!(*first < *i)); // Validate that the compare function is sane.
+				EASTL_VALIDATE_COMPARE(!eastl::less<value_type>()(*first, *i)); // Validate that the compare function is sane.
 				value_type temp(eastl::forward<value_type>(*i));
 				*i = eastl::forward<value_type>(*first);
 				eastl::adjust_heap<RandomAccessIterator, difference_type, value_type>

--- a/test/source/TestSort.cpp
+++ b/test/source/TestSort.cpp
@@ -177,7 +177,21 @@ namespace eastl
 				return x;
 			}
 		};
+
+		struct TestNoLessOperator
+		{
+			int i {};
+		};
 	} // namespace Internal
+
+	template <>
+	struct less<Internal::TestNoLessOperator>
+	{
+		bool operator()(const Internal::TestNoLessOperator& lhs, const Internal::TestNoLessOperator& rhs) const noexcept
+		{
+			return lhs.i < rhs.i;
+		}
+	};
 
 } // namespace eastl
 
@@ -793,7 +807,7 @@ int TestSort()
 	}
 
 	{
-		// EATEST_VERIFY deque sorting can compile.
+		// Test checking that deque sorting can compile.
 		deque<int>  intDeque;
 		vector<int> intVector;
 
@@ -801,6 +815,25 @@ int TestSort()
 		stable_sort(intVector.begin(), intVector.end());
 	}
 
+	{
+		// Test checking that sorting containers having elements of a type without an operator< compiles correctly
+
+		vector<TestNoLessOperator> noLessVector;
+
+		stable_sort(noLessVector.begin(), noLessVector.end());
+		bubble_sort(noLessVector.begin(), noLessVector.end());
+		shaker_sort(noLessVector.begin(), noLessVector.end());
+		insertion_sort(noLessVector.begin(), noLessVector.end());
+		selection_sort(noLessVector.begin(), noLessVector.end());
+		shell_sort(noLessVector.begin(), noLessVector.end());
+		comb_sort(noLessVector.begin(), noLessVector.end());
+		heap_sort(noLessVector.begin(), noLessVector.end());
+		merge_sort(noLessVector.begin(), noLessVector.end(), *get_default_allocator(nullptr));
+		quick_sort(noLessVector.begin(), noLessVector.end());
+
+		vector<TestNoLessOperator> buffer;
+		tim_sort_buffer(noLessVector.begin(), noLessVector.end(), buffer.data());
+}
 
 	{
 		// Test sorting of a container of pointers to objects as opposed to a container of objects themselves.


### PR DESCRIPTION
Generalized the use of `eastl::less` in several sorting-related functions. Its usage should be preferred in algorithms, to allow users specializing it for their classes instead of having to define a public operator<.
I've only fixed errors occuring in my specific case; there may be other occurrences elsewhere.

This is also applicable to `eastl::equal_to` (operator==), `eastl::not_equal_to` (operator!=), `eastl::greater` (operator>), `eastl::greater_equal` (operator>=) and `eastl::less_equal` (operator<=). Unless specialized, they all fallback on their respective operator.