### PR TITLE
Honour EA_NO_HAVE_CPP11_TUPLES before trying to include <tuple>

### DIFF
--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -974,7 +974,7 @@ EA_CONSTEXPR decltype(auto) apply(F&& f, Tuple&& t)
 ///////////////////////////////////////////////////////////////
 // C++17 structured bindings support for eastl::tuple
 //
-#ifndef EA_COMPILER_NO_STRUCTURED_BINDING
+#if !defined(EA_NO_HAVE_CPP11_TUPLES) && !defined(EA_COMPILER_NO_STRUCTURED_BINDING)
 	#include <tuple>
 	namespace std
 	{

--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -841,7 +841,7 @@ namespace eastl
 ///////////////////////////////////////////////////////////////
 // C++17 structured bindings support for eastl::pair
 //
-#ifndef EA_COMPILER_NO_STRUCTURED_BINDING
+#if !defined(EA_COMPILER_NO_STRUCTURED_BINDING) && !defined(EA_NO_HAVE_CPP11_TUPLES)
 	#include <tuple>
 	namespace std
 	{


### PR DESCRIPTION
EA_COMPILER_NO_STRUCTURED_BINDING does not properly check whether <tuple> can be included.

This change strengthens the condition to prevent build errors on C++17 when <tuple> is not available.