### PR TITLE
Allow EASTL to be used without floating point types

### DIFF
--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -454,9 +454,11 @@ namespace eastl
 			return b < a ? b : a;
 		}
 
+#if !defined(EA_COMPILER_NO_FLOATS)
 		inline EA_CONSTEXPR float       min(float  a, float   b)           { return b < a ? b : a; }
 		inline EA_CONSTEXPR double      min(double a, double  b)           { return b < a ? b : a; }
 		inline EA_CONSTEXPR long double min(long double a, long double  b) { return b < a ? b : a; }
+#endif
 
 	#endif // EASTL_MINMAX_ENABLED
 
@@ -482,9 +484,11 @@ namespace eastl
 		return b < a ? b : a;
 	}
 
+#if !defined(EA_COMPILER_NO_FLOATS)
 	inline EA_CONSTEXPR float       min_alt(float  a, float   b)           { return b < a ? b : a; }
 	inline EA_CONSTEXPR double      min_alt(double a, double  b)           { return b < a ? b : a; }
 	inline EA_CONSTEXPR long double min_alt(long double a, long double  b) { return b < a ? b : a; }
+#endif
 
 
 	#if EASTL_MINMAX_ENABLED
@@ -568,9 +572,11 @@ namespace eastl
 			return a < b ? b : a;
 		}
 
+#if !defined(EA_COMPILER_NO_FLOATS)
 		inline EA_CONSTEXPR float       max(float       a, float       b) { return a < b ? b : a; }
 		inline EA_CONSTEXPR double      max(double      a, double      b) { return a < b ? b : a; }
 		inline EA_CONSTEXPR long double max(long double a, long double b) { return a < b ? b : a; }
+#endif
 
 	#endif // EASTL_MINMAX_ENABLED
 
@@ -594,9 +600,11 @@ namespace eastl
 		return a < b ? b : a;
 	}
 
+#if !defined(EA_COMPILER_NO_FLOATS)
 	inline EA_CONSTEXPR float       max_alt(float       a, float       b) { return a < b ? b : a; }
 	inline EA_CONSTEXPR double      max_alt(double      a, double      b) { return a < b ? b : a; }
 	inline EA_CONSTEXPR long double max_alt(long double a, long double b) { return a < b ? b : a; }
+#endif
 
 
 	#if EASTL_MINMAX_ENABLED

--- a/include/EASTL/numeric_limits.h
+++ b/include/EASTL/numeric_limits.h
@@ -1333,6 +1333,7 @@ namespace eastl
 	#endif
 
 
+#if !defined(EA_COMPILER_NO_FLOATS)
 	// numeric_limits<float>
 	template<>
 	struct numeric_limits<float>
@@ -1449,7 +1450,6 @@ namespace eastl
 
 		#endif
 	};
-
 
 	// numeric_limits<double>
 	template<>
@@ -1685,6 +1685,7 @@ namespace eastl
 
 		#endif
 	};
+#endif
 
 } // namespace eastl
 

--- a/source/hashtable.cpp
+++ b/source/hashtable.cpp
@@ -2,6 +2,9 @@
 // Copyright (c) Electronic Arts Inc. All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <EABase/config/eacompiler.h>
+
+#if !defined(EA_COMPILER_NO_FLOATS)
 
 #include <EASTL/internal/hashtable.h>
 #include <EASTL/utility.h>
@@ -175,3 +178,5 @@ namespace eastl
 } // namespace eastl
 
 EA_RESTORE_VC_WARNING();
+
+#endif

--- a/source/numeric_limits.cpp
+++ b/source/numeric_limits.cpp
@@ -493,6 +493,8 @@
 			EA_CONSTEXPR_OR_CONST bool                  numeric_limits<__int128_t>::is_iec559;
 		#endif
 
+
+#if !defined(EA_COMPILER_NO_FLOATS)
 		// float
 		EA_CONSTEXPR_OR_CONST bool                  numeric_limits<float>::is_specialized;
 		EA_CONSTEXPR_OR_CONST int                   numeric_limits<float>::digits;
@@ -564,6 +566,7 @@
 		EA_CONSTEXPR_OR_CONST float_denorm_style    numeric_limits<long double>::has_denorm;
 		EA_CONSTEXPR_OR_CONST bool                  numeric_limits<long double>::has_denorm_loss;
 		EA_CONSTEXPR_OR_CONST bool                  numeric_limits<long double>::is_iec559;
+#endif
 
 	} // namespace eastl
 


### PR DESCRIPTION
Depends on EABase#6 - this is mainly useful for environments where floating point support is not available, such as kernel code.