### PR TITLE
atomic macros: replace static_assert(false) condition by a dependent type always false (fix VS 2022 compilation error)

### DIFF
--- a/include/EASTL/internal/atomic/atomic_macros/atomic_macros_base.h
+++ b/include/EASTL/internal/atomic/atomic_macros/atomic_macros_base.h
@@ -10,6 +10,8 @@
 	#pragma once
 #endif
 
+template<typename>
+constexpr bool eastl_atomic_always_false = false;
 
 #define EASTL_ATOMIC_INTERNAL_COMPILER_AVAILABLE(op)					\
 	EA_PREPROCESSOR_JOIN(EA_PREPROCESSOR_JOIN(EASTL_COMPILER_, op), _AVAILABLE)
@@ -18,7 +20,7 @@
 	EA_PREPROCESSOR_JOIN(EA_PREPROCESSOR_JOIN(EASTL_ARCH_, op), _AVAILABLE)
 
 #define EASTL_ATOMIC_INTERNAL_NOT_IMPLEMENTED_ERROR(...)				\
-	static_assert(false, "eastl::atomic<T> atomic macro not implemented!")
+	static_assert(eastl_atomic_always_false<T>, "eastl::atomic<T> atomic macro not implemented!")
 
 
 /* Compiler && Arch Not Implemented */


### PR DESCRIPTION
With VS 2022, `static_assert(false)` will always failed, event inside template code never instantiate.
A dependent type need to be use.
See https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#error-on-a-non-dependent-static_assert

If there is a better name for `eastl_atomic_always_false` tell me