### PR TITLE
map::at(): exception must be throw (or assertion) if element, smaller than the first one, is not present

### DIFF
--- a/include/EASTL/map.h
+++ b/include/EASTL/map.h
@@ -445,7 +445,7 @@ namespace eastl
 	{
 		iterator itLower(lower_bound(key)); // itLower->first is >= key.
 
-		if(itLower == end())
+		if(itLower == end() || compare(key, (*itLower).first))
 		{
 			#if EASTL_EXCEPTIONS_ENABLED
 				throw std::out_of_range("map::at key does not exist");
@@ -463,7 +463,7 @@ namespace eastl
 	{
 		const_iterator itLower(lower_bound(key)); // itLower->first is >= key.
 
-		if(itLower == end())
+		if(itLower == end() || compare(key, (*itLower).first))
 		{
 			#if EASTL_EXCEPTIONS_ENABLED
 				throw std::out_of_range("map::at key does not exist");

--- a/test/source/TestMap.cpp
+++ b/test/source/TestMap.cpp
@@ -167,6 +167,24 @@ int TestMap()
 		EATEST_VERIFY(map3.at(0) == 1);
 	}
 
+	// User regression test, exception must be throw if search element, smaller than the first one, is not present.
+	{
+		typedef eastl::map<int, int>     IntIntMap;
+		IntIntMap map1;
+
+		map1.emplace(2, 100);
+
+		#if EASTL_EXCEPTIONS_ENABLED
+			EATEST_VERIFY_THROW(map1.at(0));
+		#endif
+
+		// Same test on const map
+		const IntIntMap& map2 = map1;
+		#if EASTL_EXCEPTIONS_ENABLED
+			EATEST_VERIFY_THROW(map2.at(0));
+		#endif
+	}
+
 	// User regression test
 	{
 	#if !EASTL_RBTREE_LEGACY_SWAP_BEHAVIOUR_REQUIRES_COPY_CTOR


### PR DESCRIPTION
map::at() do throw/generate error if at is call on value smaller than the first element.
```c++
		eastl::map<int, int> m;
		m.emplace(2, 85);
		auto v = m.at(0); // Must throw
``` 