### PR TITLE
variant constructor and assignment shouldn't allow narrow conversion

### DIFF
--- a/include/EASTL/meta.h
+++ b/include/EASTL/meta.h
@@ -181,17 +181,21 @@ namespace eastl
 		// overload_resolution has selected a function to run.
 		//
 
+		// Helper used to check for valid conversions that don't involve narrowing.
+		template <class T>
+		T make_overload_array(T(&&)[1]);
+
 		// a single overload of an individual type
 		template <typename T>
 		struct overload
 		{
-			// Overload is implicitly convertible to the surrogated function
-			// call for pointer to member functions (pmf). This gets around
-			// variadic pack expansion in a class using statement being a C++17
-			// language feature. It is the core mechanism of aggregating all the
+			// Overload is a functor that will be selected by overload resolution
+			// if and only if there's no narrow conversion to convert ParamType into T.
+			// This gets around variadic pack expansion in a class using statement being
+			// a C++17 language feature. It is the core mechanism of aggregating all the
 			// individual overloads into the overload_set structure.
-			using F = T (*)(T);
-			operator F() const { return nullptr; }
+			template <class ParamType, typename = decltype(make_overload_array<T>({declval<ParamType>()}))>
+			T operator()(T, ParamType&&);
 		};
 
 		template <typename...> struct overload_set_impl;
@@ -206,7 +210,9 @@ namespace eastl
 		};
 
 		EA_DISABLE_VC_WARNING(4242 4244) // conversion from 'T' to 'U', possible loss of data.
-		template <typename T, typename OverloadSet, typename ResultT = decltype(declval<OverloadSet>()(declval<T>()))>
+		template <typename T,
+		          typename OverloadSet,
+		          typename ResultT = decltype(declval<OverloadSet>()(declval<T>(), declval<T>()))>
 		struct overload_resolution
 		{
 			// capture the return type of the function the compiler selected by

--- a/test/source/TestMeta.cpp
+++ b/test/source/TestMeta.cpp
@@ -80,12 +80,12 @@ int TestOverloadResolution()
 	int nErrorCount = 0;
 
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<int>>, int>, "error");
-	static_assert(is_same_v<overload_resolution_t<int, overload_set<short>>, short>, "error");
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<long>>, long>, "error");
 	static_assert(is_same_v<overload_resolution_t<short, overload_set<int>>, int>, "error");
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<int, short, long>>, int>, "error");
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<short, int, long, float>>, int>, "error");
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<short, long, int, float, char>>, int>, "error");
+	static_assert(is_same_v<overload_resolution_t<int, overload_set<float, int, double>>, int>, "error");
 
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<int>>, int>, "error");
 	static_assert(is_same_v<overload_resolution_t<int, overload_set<int, short>>, int>, "error");

--- a/test/source/TestVariant.cpp
+++ b/test/source/TestVariant.cpp
@@ -205,6 +205,18 @@ int TestVariantBasic()
 		VERIFY(*(get_if<string>(&v)) == "a");
 	}
 
+	{
+		// verify construction where only one candidate doesn't require narrow conversion
+		variant<float, long, double> v = 42;
+		VERIFY(holds_alternative<long>(v));
+		VERIFY(get<long>(v) == 42);
+
+		// and assignment operator=
+		v = 43;
+		VERIFY(holds_alternative<long>(v));
+		VERIFY(get<long>(v) == 43);
+	}
+
 	return nErrorCount;
 }
 


### PR DESCRIPTION
According to the standard, the constructor of a variant should construct a variant holding an alternative type T_i from an input of type T only if no narrow conversion is performed between T and T_i.

See documentation here: https://en.cppreference.com/w/cpp/utility/variant/variant
Constructor 4:
 > An overload F(T_i) is only considered if the declaration T_i x[] = { std::forward<T>(t) }; is valid

As a direct consequence, the following code is valid (taken from the link above):
```cpp
variant<float, long, double> z = 0; // OK, holds long
                                    // float and double are not candidates
```