### PR TITLE
Removed (reduntant) template id for destructor.

### DIFF
--- a/include/EASTL/internal/type_pod.h
+++ b/include/EASTL/internal/type_pod.h
@@ -1721,7 +1721,7 @@ namespace eastl
 		template <typename>
 		eastl::false_type destructible_test_function(...);
 		
-		template <typename T, typename U = decltype(eastl::declval<eastl::destructible_test_helper<T> >().~destructible_test_helper<T>())>
+		template <typename T, typename U = decltype(eastl::declval<eastl::destructible_test_helper<T> >().~destructible_test_helper())>
 		eastl::true_type destructible_test_function(int);
 
 		template <typename T, bool = eastl::is_array_of_unknown_bounds<T>::value || // Exclude these types from being considered destructible.


### PR DESCRIPTION
The EASTL doesn't compile when using C++ 20 in GCC 11.2.1, because of line 1724. This modification makes it compile when using -std=c++20.