### PR TITLE
Avoid using `_FInf` etc. in `numeric_limits.h` after MSVC's STL removes them

### DIFF
--- a/include/EASTL/numeric_limits.h
+++ b/include/EASTL/numeric_limits.h
@@ -1435,6 +1435,19 @@ namespace eastl
 			static value_type round_error() 
 				{ return 0.5f; }
 
+			#if defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202206L // If using a recent version of MSVC's STL...
+			static value_type infinity()
+				{ return __builtin_huge_valf(); }
+
+			static value_type quiet_NaN()
+				{ return __builtin_nanf("0"); }
+
+			static value_type signaling_NaN()
+				{ return __builtin_nansf("1"); }
+
+			static value_type denorm_min()
+				{ return FLT_TRUE_MIN; }
+			#else
 			static value_type infinity() 
 				{ return _CSTD _FInf._Float; }
 
@@ -1446,6 +1459,7 @@ namespace eastl
 
 			static value_type denorm_min() 
 				{ return _CSTD _FDenorm._Float; }
+			#endif
 
 		#endif
 	};
@@ -1553,6 +1567,19 @@ namespace eastl
 			static value_type round_error() 
 				{ return 0.5f; }
 
+			#if defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202206L // If using a recent version of MSVC's STL...
+			static value_type infinity()
+				{ return __builtin_huge_val(); }
+
+			static value_type quiet_NaN()
+				{ return __builtin_nan("0"); }
+
+			static value_type signaling_NaN()
+				{ return __builtin_nans("1"); }
+
+			static value_type denorm_min()
+				{ return DBL_TRUE_MIN; }
+			#else
 			static value_type infinity() 
 				{ return _CSTD _Inf._Double; }
 
@@ -1564,6 +1591,7 @@ namespace eastl
 
 			static value_type denorm_min() 
 				{ return _CSTD _Denorm._Double; }
+			#endif
 
 		#endif
 	};
@@ -1671,6 +1699,19 @@ namespace eastl
 			static value_type round_error() 
 				{ return 0.5f; }
 
+			#if defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202206L // If using a recent version of MSVC's STL...
+			static value_type infinity()
+				{ return __builtin_huge_val(); }
+
+			static value_type quiet_NaN()
+				{ return __builtin_nan("0"); }
+
+			static value_type signaling_NaN()
+				{ return __builtin_nans("1"); }
+
+			static value_type denorm_min()
+				{ return LDBL_TRUE_MIN; }
+			#else
 			static value_type infinity() 
 				{ return _CSTD _LInf._Long_double; }
 
@@ -1682,6 +1723,7 @@ namespace eastl
 
 			static value_type denorm_min() 
 				{ return _CSTD _LDenorm._Long_double; }
+			#endif
 
 		#endif
 	};


### PR DESCRIPTION
I work on the Visual C++ team, where we regularly build many open-source projects, including EASTL, with development builds of the MSVC compiler and libraries, in order to prevent regressions that would affect projects. This also allows us to provide advance notice of breaking changes, such as this one:

We've merged https://github.com/microsoft/STL/pull/2828, which is removing the declarations of the `_FInf` etc. variables from our headers. This change will ship in VS 2022 17.4 Preview 2, and it breaks EASTL because MSVC's STL still defines `_CPPLIB_VER` (identifying ourselves as Dinkumware-derived sources).

This PR uses our supported macro [`_MSVC_STL_UPDATE`](https://github.com/microsoft/STL/wiki/Macro-_MSVC_STL_UPDATE) for identifying the updated versions of MSVC's STL, and instead uses the compiler's `__builtin_huge_valf()` etc. intrinsics, plus `FLT_TRUE_MIN` etc. from the UCRT.

These intrinsics and macros have been available for quite some time. Note that they will improve codegen, as they produce constants that are known to the compiler. In contrast, the old internal variables are separately compiled (and modifiable!), which inhibits optimizations like constant propagation.

