### PR TITLE
variant: fix unused args warnings

### DIFF
--- a/include/EASTL/variant.h
+++ b/include/EASTL/variant.h
@@ -130,7 +130,7 @@ namespace eastl
 		template<typename T>
 		struct destroy_if_supported<T, false>
 		{
-			static void call(T* pThis) {} // intentionally blank
+			static void call(T*) {} // intentionally blank
 		};
 
 		///////////////////////////////////////////////////////////////////////////
@@ -153,7 +153,7 @@ namespace eastl
 		template<typename T>
 		struct copy_if_supported<T, false>
 		{
-			static void call(T* pThis, T* pOther) {} // intentionally blank
+			static void call(T*, T*) {} // intentionally blank
 		};
 
 		///////////////////////////////////////////////////////////////////////////
@@ -176,7 +176,7 @@ namespace eastl
 		template<typename T>
 		struct move_if_supported<T, false>
 		{
-			static void call(T* pThis, T* pOther) {} // intentionally blank
+			static void call(T*, T*) {} // intentionally blank
 		};
 	} // namespace internal
 
@@ -210,6 +210,8 @@ namespace eastl
 			throw bad_variant_access();
 	#elif EASTL_ASSERT_ENABLED
 		EASTL_ASSERT_MSG(b, "eastl::bad_variant_access assert");
+	#else
+		EA_UNUSED(b);
 	#endif
 	}
 
@@ -533,7 +535,7 @@ namespace eastl
 	//
 	template <class... Types>
 	struct hash<variant<Types...> >
-		{ size_t operator()(const variant<Types...>& val) const { return static_cast<size_t>(-0x42); } };
+		{ size_t operator()(const variant<Types...>&) const { return static_cast<size_t>(-0x42); } };
 
 
 	///////////////////////////////////////////////////////////////////////////
@@ -1076,13 +1078,13 @@ namespace eastl
 
 
 	template <size_t N, typename Variant, typename... Variants, eastl::enable_if_t<N == 0, int> = 0>
-	static EA_CONSTEXPR decltype(auto) get_variant_n(Variant&& variant, Variants&&... variants)
+	static EA_CONSTEXPR decltype(auto) get_variant_n(Variant&& variant, Variants&&...)
 	{
 		return eastl::forward<Variant>(variant);
 	}
 
 	template <size_t N, typename Variant, typename... Variants, eastl::enable_if_t<N != 0, int> = 0>
-	static EA_CONSTEXPR decltype(auto) get_variant_n(Variant&& variant, Variants&&... variants)
+	static EA_CONSTEXPR decltype(auto) get_variant_n(Variant&&, Variants&&... variants)
 	{
 		return get_variant_n<N - 1>(eastl::forward<Variants>(variants)...);
 	}
@@ -1348,7 +1350,7 @@ namespace eastl
 	//     variant<int, long, string> v = "Hello, Variant";
 	//     visit(MyVisitor{}, v);  // calls MyVisitor::operator()(string) {}
 	//
-
+	EA_DISABLE_VC_WARNING(4100) // warning C4100: 't': unreferenced formal parameter
 	template <typename... Variants>
 	static EA_CPP14_CONSTEXPR void visit_throw_bad_variant_access(Variants&&... variants)
 	{
@@ -1374,7 +1376,7 @@ namespace eastl
 		static_assert(conjunction_v<is_same<variant_type, decay_t<Variants>>...>,
 					  "`visit` all variants passed to eastl::visit() must have the same type");
 	}
-
+	EA_RESTORE_VC_WARNING()
 
 	// visit
 	//


### PR DESCRIPTION
Some of them are clang-specific (might even require /permissive-), other - msvc.

Example of warning
variant.h(133,24): error: unused parameter 'pThis' [-Werror,-Wunused-parameter]