### PR TITLE
Add non-explicit default ctor for hash_map and hash_set.

### DIFF
--- a/include/EASTL/hash_map.h
+++ b/include/EASTL/hash_map.h
@@ -125,8 +125,19 @@ namespace eastl
 		///
 		/// Default constructor.
 		///
-		explicit hash_map(const allocator_type& allocator = EASTL_HASH_MAP_DEFAULT_ALLOCATOR)
-			: base_type(0, Hash(), mod_range_hashing(), default_ranged_hash(), 
+		hash_map()
+			: this_type(EASTL_HASH_MAP_DEFAULT_ALLOCATOR)
+		{
+			// Empty
+		}
+
+
+		/// hash_map
+		///
+		/// Constructor which creates an empty container with allocator.
+		///
+		explicit hash_map(const allocator_type& allocator)
+			: base_type(0, Hash(), mod_range_hashing(), default_ranged_hash(),
 						Predicate(), eastl::use_first<eastl::pair<const Key, T> >(), allocator)
 		{
 			// Empty

--- a/include/EASTL/hash_set.h
+++ b/include/EASTL/hash_set.h
@@ -117,8 +117,19 @@ namespace eastl
 		/// hash_set
 		///
 		/// Default constructor.
-		/// 
-		explicit hash_set(const allocator_type& allocator = EASTL_HASH_SET_DEFAULT_ALLOCATOR)
+		///
+		hash_set()
+			: this_type(EASTL_HASH_SET_DEFAULT_ALLOCATOR)
+		{
+			// Empty
+		}
+
+
+		/// hash_set
+		///
+		/// Constructor which creates an empty container with allocator.
+		///
+		explicit hash_set(const allocator_type& allocator)
 			: base_type(0, Hash(), mod_range_hashing(), default_ranged_hash(), Predicate(), eastl::use_self<Value>(), allocator)
 		{
 			// Empty


### PR DESCRIPTION
It's annoying that default ctors of map and set are explicit, because the following code doesn't compile:

```
struct Test
{
    eastl::unordered_map<int, int> m;
};

Test t = {};
```
and I **must** do `m{};`