### PR TITLE
Re-add install commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,3 +52,8 @@ endif()
 
 target_link_libraries(EASTL EABase)
 
+#-------------------------------------------------------------------------------------------
+# Installation
+#-------------------------------------------------------------------------------------------
+install(TARGETS EASTL DESTINATION lib)
+install(DIRECTORY include/EASTL DESTINATION include)


### PR DESCRIPTION
This adds back the install commands that were removed in an earlier commit.

This is the same as #423 but does not include any other changes and is based on the current head commit.