### PR TITLE
Fix fixed_string resize within SSO capacity

### DIFF
--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -1415,8 +1415,14 @@ namespace eastl
 					pointer pOldBegin = internalLayout().BeginPtr();
 					const size_type nOldCap = internalLayout().GetHeapCapacity();
 
-					CharStringUninitializedCopy(pOldBegin, pOldBegin + n, internalLayout().SSOBeginPtr());
-					internalLayout().SetSSOSize(n);
+					// Usually the SSO capacity is smaller than the heap
+					// capacity. However, fixed_string's internal buffer is
+					// handled as heap memory and might actually be smaller than
+					// the SSO buffer. 
+					const size_type nCopyOverSize = min(nOldCap, n);
+
+					CharStringUninitializedCopy(pOldBegin, pOldBegin + nCopyOverSize, internalLayout().SSOBeginPtr());
+					internalLayout().SetSSOSize(nCopyOverSize);
 					*internalLayout().SSOEndPtr() = 0;
 
 					DoFree(pOldBegin, nOldCap + 1);

--- a/test/source/TestFixedString.cpp
+++ b/test/source/TestFixedString.cpp
@@ -449,6 +449,20 @@ int TestFixedString()
 	}
 
 	{
+		// Test overflow allocator while within SSO
+		typedef fixed_string<char8_t, 8, true, MallocAllocator> FixedString8Malloc;
+		FixedString8Malloc fs;
+		for (char c = 'a'; c <= 'l'; ++c) {
+			fs.push_back(c);
+		}
+
+		// We expect the string content to reside in the SSO buffer.
+		EATEST_VERIFY(fs.internalLayout().IsSSO());
+		EATEST_VERIFY(fs == "abcdefghijkl");
+		EATEST_VERIFY(fs.size() == 12);
+	}
+
+	{
 		// Test construction of a container with an overflow allocator constructor argument.
 		MallocAllocator overflowAllocator;
 		void* p = overflowAllocator.allocate(1);


### PR DESCRIPTION
As pointed out in #454, when fixed_string gets resized but capacity stays within SSO capacity the null-terminator gets copied over as well. The corresponding code assumes heap capacity is always greater than SSO capacity. fixed_string's internal buffer is handled as heap inside the string class and may, in fact, be <= SSO capacity.

This commit fixes the described issue and adds a unit test for this specific case.