### PR TITLE
Add automatic conversion between std::string_view and eastl::string_view

### DIFF
--- a/include/EASTL/string_view.h
+++ b/include/EASTL/string_view.h
@@ -28,6 +28,10 @@
 	EA_RESTORE_ALL_VC_WARNINGS()
 #endif
 
+#if EASTL_STRING_VIEW_STD_CONVERSION_ENABLED
+	#include <string_view>
+#endif
+
 EA_DISABLE_VC_WARNING(4814)
 
 namespace eastl
@@ -62,6 +66,11 @@ namespace eastl
 		EA_CONSTEXPR basic_string_view(const T* s, size_type count) : mpBegin(s), mnCount(count) {}
 		EA_CONSTEXPR basic_string_view(const T* s) : mpBegin(s), mnCount(s != nullptr ? CharStrlen(s) : 0) {}
 		basic_string_view& operator=(const basic_string_view& view) = default;
+
+		#if EASTL_STRING_VIEW_STD_CONVERSION_ENABLED
+			EA_CONSTEXPR basic_string_view(const std::basic_string_view<T>& stdView) : basic_string_view(stdView.data(), stdView.size()) {}
+		#endif
+
 
 		// 21.4.2.2, iterator support
 		EA_CONSTEXPR const_iterator begin() const EA_NOEXCEPT { return mpBegin; }
@@ -446,6 +455,13 @@ namespace eastl
 		{
 			return ends_with(basic_string_view(s));
 		}
+
+		#if EASTL_STRING_VIEW_STD_CONVERSION_ENABLED
+			EA_CONSTEXPR operator std::string_view()
+			{
+				return std::string_view{begin(), size()};
+			}
+		#endif
 	};
 
 

--- a/test/source/TestStringView.cpp
+++ b/test/source/TestStringView.cpp
@@ -109,6 +109,23 @@ int TestStringView()
 		VERIFY(sw.size() == wcslen(pStr));
 	}
 
+	#if EASTL_STRING_VIEW_STD_CONVERSION_ENABLED
+		// automatic conversion between std::string_view and eastl::string_view
+		{
+			eastl::string_view originalString = "Hello World";
+
+			std::string_view stdView{originalString};
+			stdView = originalString;
+			eastl::string_view eastlView{stdView};
+			eastlView = stdView;
+
+			const auto fnTakingStdView = [](std::string_view) {};
+			fnTakingStdView(eastlView);
+
+			const auto fnTakingEastlView = [](eastl::string_view) {};
+			fnTakingEastlView(stdView);
+		}
+	#endif
 
 	return nErrorCount;
 }


### PR DESCRIPTION
While eastl containers are interoperable with std algorithms thanks to iterators, strings are typically not handled through iterators.
Converting an eastl string to an std string is problematic and string_views are a better tool for this.

This commit adds automatic conversion between `std::string_view` and `eastl::string_view`.

The feature (and corresponding unit test) is guarded by `EASTL_STRING_VIEW_STD_CONVERSION_ENABLED`.
Let me know where to add `EASTL_STRING_VIEW_STD_CONVERSION_ENABLED` such that it is correctly picked up by testing facilities.