### PR TITLE
Version 3.20.02.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Testing/*
 /buckaroo/
 .buckconfig.local
 BUCKAROO_DEPS
+.vscode/settings.json

--- a/doc/EASTL.natvis
+++ b/doc/EASTL.natvis
@@ -392,9 +392,9 @@
 		<Synthetic Name="NOTE!">
 		  <DisplayString>It is possible to expand parents that do not exist.</DisplayString> 
 		</Synthetic>
-		<Item Name="Parent">*(eastl::rbtree_node&lt;$T2&gt;*)(mpNodeParent.value &amp; (~uintptr_t(1)))</Item>
-		<Item Name="Left">*(eastl::rbtree_node&lt;$T2&gt;*)mpNodeLeft</Item>
-		<Item Name="Right">*(eastl::rbtree_node&lt;$T2&gt;*)mpNodeRight</Item>
+		<Item Name="Parent">*(eastl::rbtree_node&lt;$T1&gt;*)mpNodeParent</Item>
+		<Item Name="Left">*(eastl::rbtree_node&lt;$T1&gt;*)mpNodeLeft</Item>
+		<Item Name="Right">*(eastl::rbtree_node&lt;$T1&gt;*)mpNodeRight</Item>
 	</Expand>
 </Type>
 

--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -4309,9 +4309,8 @@ namespace eastl
 	template <class T, class Compare>
 	EA_CONSTEXPR const T& clamp(const T& v, const T& lo, const T& hi, Compare comp)
 	{
-		// code collapsed to a single line due to constexpr requirements
-		return [&] { EASTL_ASSERT(!comp(hi, lo)); }(),
-			   comp(v, lo) ? lo : comp(hi, v) ? hi : v;
+		EASTL_ASSERT(!comp(hi, lo));
+		return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
 	}
 
 	template <class T>

--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -89,8 +89,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef EASTL_VERSION
-	#define EASTL_VERSION   "3.19.05"
-	#define EASTL_VERSION_N  31905
+	#define EASTL_VERSION   "3.20.02"
+	#define EASTL_VERSION_N  32002
 #endif
 
 
@@ -1855,15 +1855,46 @@ typedef EASTL_SSIZE_T eastl_ssize_t; // Signed version of eastl_size_t. Concept 
 
 /// EASTL_HAS_UNIQUE_OBJECT_REPRESENTATIONS_AVAILABLE
 #if defined(__clang__)
+	// NB: !__is_identifier() is correct: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66970#c11
 	#if !__is_identifier(__has_unique_object_representations)
 		#define EASTL_HAS_UNIQUE_OBJECT_REPRESENTATIONS_AVAILABLE 1
 	#else
 		#define EASTL_HAS_UNIQUE_OBJECT_REPRESENTATIONS_AVAILABLE 0
 	#endif
-#elif defined(_MSC_VER) && (_MSC_VER >= 1913)  // VS2017+
+#elif defined(_MSC_VER) && (_MSC_VER >= 1913)  // VS2017 15.6+
 	#define EASTL_HAS_UNIQUE_OBJECT_REPRESENTATIONS_AVAILABLE 1
 #else
 	#define EASTL_HAS_UNIQUE_OBJECT_REPRESENTATIONS_AVAILABLE 0
+#endif
+
+#if defined(__clang__)
+	// NB: !__is_identifier() is correct: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66970#c11
+	#if !__is_identifier(__is_final)
+		#define EASTL_IS_FINAL_AVAILABLE 1
+	#else
+		#define EASTL_IS_FINAL_AVAILABLE 0
+	#endif
+#elif defined(_MSC_VER) && (_MSC_VER >= 1914)	// VS2017 15.7+
+	#define EASTL_IS_FINAL_AVAILABLE 1
+#elif defined(EA_COMPILER_GNUC)
+	#define EASTL_IS_FINAL_AVAILABLE 1
+#else
+	#define EASTL_IS_FINAL_AVAILABLE 0
+#endif
+
+#if defined(__clang__)
+	// NB: !__is_identifier() is correct: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66970#c11
+	#if !__is_identifier(__is_aggregate)
+		#define EASTL_IS_AGGREGATE_AVAILABLE 1
+	#else
+		#define EASTL_IS_AGGREGATE_AVAILABLE 0
+	#endif
+#elif defined(_MSC_VER) && (_MSC_VER >= 1915)  // VS2017 15.8+
+	#define EASTL_IS_AGGREGATE_AVAILABLE 1
+#elif defined(EA_COMPILER_GNUC)
+	#define EASTL_IS_AGGREGATE_AVAILABLE 1
+#else
+	#define EASTL_IS_AGGREGATE_AVAILABLE 0
 #endif
 
 

--- a/include/EASTL/internal/fixed_pool.h
+++ b/include/EASTL/internal/fixed_pool.h
@@ -1363,9 +1363,8 @@ namespace eastl
 		}
 
 		fixed_vector_allocator(const fixed_vector_allocator& x)
+			: mOverflowAllocator(x.mOverflowAllocator), mpPoolBegin(x.mpPoolBegin)
 		{
-		   mpPoolBegin        = x.mpPoolBegin;
-		   mOverflowAllocator = x.mOverflowAllocator;
 		}
 
 		fixed_vector_allocator& operator=(const fixed_vector_allocator& x)

--- a/include/EASTL/internal/type_compound.h
+++ b/include/EASTL/internal/type_compound.h
@@ -128,58 +128,18 @@ namespace eastl
 
 	#define EASTL_TYPE_TRAIT_is_member_function_pointer_CONFORMANCE 1    // is_member_function_pointer is conforming; doesn't make mistakes.
 
-	// To do: Revise this to support C++11 variadic templates when possible.
-	// To do: We can probably also use remove_cv to simply the multitude of types below.
+	namespace internal
+	{
+		template<typename T>
+		struct is_member_function_pointer_helper : false_type {};
 
-	template <typename T> struct is_mem_fun_pointer_value : public false_type{};
+		template<typename T, typename U>
+		struct is_member_function_pointer_helper<T U::*> : is_function<T> {};
+	}
 
-	template <typename R, typename T> struct is_mem_fun_pointer_value<R (T::*)()> : public true_type{};
-	template <typename R, typename T> struct is_mem_fun_pointer_value<R (T::*)() const> : public true_type{};
-	template <typename R, typename T> struct is_mem_fun_pointer_value<R (T::*)() volatile> : public true_type{};
-	template <typename R, typename T> struct is_mem_fun_pointer_value<R (T::*)() const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0> struct is_mem_fun_pointer_value<R (T::*)(Arg0)> : public true_type{};
-	template <typename R, typename T, typename Arg0> struct is_mem_fun_pointer_value<R (T::*)(Arg0) const> : public true_type{};
-	template <typename R, typename T, typename Arg0> struct is_mem_fun_pointer_value<R (T::*)(Arg0) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0> struct is_mem_fun_pointer_value<R (T::*)(Arg0) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) const volatile> : public true_type{};
-
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) const> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) volatile> : public true_type{};
-	template <typename R, typename T, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7> struct is_mem_fun_pointer_value<R (T::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) const volatile> : public true_type{};
-
-	template <typename T> 
-	struct is_member_function_pointer : public integral_constant<bool, is_mem_fun_pointer_value<T>::value>{};
+	template<typename T>
+	struct is_member_function_pointer
+		: internal::is_member_function_pointer_helper<typename remove_cv<T>::type> {};
 
 	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template<typename T>
@@ -198,13 +158,19 @@ namespace eastl
 
 	#define EASTL_TYPE_TRAIT_is_member_pointer_CONFORMANCE 1    // is_member_pointer is conforming; doesn't make mistakes.
 
-	template <typename T> 
-	struct is_member_pointer 
-		: public eastl::integral_constant<bool, eastl::is_member_function_pointer<T>::value>{};
+	namespace internal {
+		template <typename T>
+		struct is_member_pointer_helper
+			: public eastl::false_type {};
 
-	template <typename T, typename U>
-	struct is_member_pointer<U T::*> 
-		: public eastl::true_type{};
+		template <typename T, typename U>
+		struct is_member_pointer_helper<U T::*>
+			: public eastl::true_type {};
+	}
+
+	template<typename T>
+	struct is_member_pointer
+		: public internal::is_member_pointer_helper<typename remove_cv<T>::type>::type {};
 
 	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template<typename T>
@@ -690,7 +656,7 @@ namespace eastl
 	///////////////////////////////////////////////////////////////////////
 	// is_final
 	///////////////////////////////////////////////////////////////////////
-	#if EA_COMPILER_HAS_FEATURE(is_final)
+	#if EASTL_IS_FINAL_AVAILABLE == 1
 		template <typename T>
 		struct is_final : public integral_constant<bool, __is_final(T)> {};
 	#else
@@ -722,7 +688,7 @@ namespace eastl
 	//     * no default member initializers
 	//
 	///////////////////////////////////////////////////////////////////////
-	#if EA_COMPILER_HAS_FEATURE(is_aggregate) || defined(_MSC_VER) && (_MSC_VER >= 1916)  // VS2017 15.9+
+	#if EASTL_IS_AGGREGATE_AVAILABLE == 1
 		#define EASTL_TYPE_TRAIT_is_aggregate_CONFORMANCE 1  
 
 		template <typename T>

--- a/include/EASTL/internal/type_pod.h
+++ b/include/EASTL/internal/type_pod.h
@@ -693,7 +693,7 @@ namespace eastl
 		//
 
 		template <typename T>
-		struct is_trivially_copyable { static const bool value = __is_trivially_copyable(T); };
+		struct is_trivially_copyable : public bool_constant<__is_trivially_copyable(T)> {};
 
 	#elif EASTL_COMPILER_INTRINSIC_TYPE_TRAITS_AVAILABLE && (defined(EA_COMPILER_MSVC) || defined(EA_COMPILER_GNUC))
 		#define EASTL_TYPE_TRAIT_is_trivially_copyable_CONFORMANCE 1
@@ -850,7 +850,7 @@ namespace eastl
 		// whether the __is_trivially_constructible compiler intrinsic is available.
 
 		// If the compiler has this trait built-in (which ideally all compilers would have since it's necessary for full conformance) use it.
-		#if EASTL_COMPILER_INTRINSIC_TYPE_TRAITS_AVAILABLE && (defined(__clang__) && EA_COMPILER_HAS_FEATURE(is_trivially_constructible))
+		#if EASTL_COMPILER_INTRINSIC_TYPE_TRAITS_AVAILABLE && ((defined(__clang__) && EA_COMPILER_HAS_FEATURE(is_trivially_constructible)) || defined(EA_COMPILER_MSVC))
 
 			template <typename T, typename Arg0 = eastl::unused>
 			struct is_trivially_constructible 
@@ -915,7 +915,7 @@ namespace eastl
 	#else
 
 		// If the compiler has this trait built-in (which ideally all compilers would have since it's necessary for full conformance) use it.
-		#if EASTL_COMPILER_INTRINSIC_TYPE_TRAITS_AVAILABLE && (defined(__clang__) && EA_COMPILER_HAS_FEATURE(is_trivially_constructible))
+		#if EASTL_COMPILER_INTRINSIC_TYPE_TRAITS_AVAILABLE && ((defined(__clang__) && EA_COMPILER_HAS_FEATURE(is_trivially_constructible)) || defined(EA_COMPILER_MSVC))
 			#define EASTL_TYPE_TRAIT_is_trivially_constructible_CONFORMANCE 1
 
 			// We have a problem with clang here as of clang 3.4: __is_trivially_constructible(int[]) is false, yet I believe it should be true.

--- a/include/EASTL/internal/type_properties.h
+++ b/include/EASTL/internal/type_properties.h
@@ -104,51 +104,31 @@ namespace eastl
     ///////////////////////////////////////////////////////////////////////
 	// is_signed
 	//
-	// is_signed<T>::value == true if and only if T is one of the following types:
-	//    [const] [volatile] char (maybe)
-	//    [const] [volatile] signed char
-	//    [const] [volatile] short
-	//    [const] [volatile] int
-	//    [const] [volatile] long
-	//    [const] [volatile] long long
-	//    [const] [volatile] float
-	//    [const] [volatile] double
-	//    [const] [volatile] long double
+	// is_signed<T>::value == true if T is a (possibly cv-qualified) floating-point or signed integer type.
 	//
-	// Used to determine if a integral type is signed or unsigned.
+	// Used to determine if a type is signed.
 	// Given that there are some user-made classes which emulate integral
 	// types, we provide the EASTL_DECLARE_SIGNED macro to allow you to
 	// set a given class to be identified as a signed type.
 	///////////////////////////////////////////////////////////////////////
 
 	#define EASTL_TYPE_TRAIT_is_signed_CONFORMANCE 1    // is_signed is conforming.
-
-	template <typename T> struct is_signed_helper : public false_type{};
-
-	template <> struct is_signed_helper<signed char>      : public true_type{};
-	template <> struct is_signed_helper<signed short>     : public true_type{};
-	template <> struct is_signed_helper<signed int>       : public true_type{};
-	template <> struct is_signed_helper<signed long>      : public true_type{};
-	template <> struct is_signed_helper<signed long long> : public true_type{};
-	template <> struct is_signed_helper<float>            : public true_type{};
-	template <> struct is_signed_helper<double>           : public true_type{};
-	template <> struct is_signed_helper<long double>      : public true_type{};
-
-	#if (CHAR_MAX == SCHAR_MAX)
-		template <> struct is_signed_helper<char>         : public true_type{};
-	#endif
-	#ifndef EA_WCHAR_T_NON_NATIVE // If wchar_t is a native type instead of simply a define to an existing type...
-		#if defined(__WCHAR_MAX__) && ((__WCHAR_MAX__ == 2147483647) || (__WCHAR_MAX__ == 32767)) // GCC defines __WCHAR_MAX__ for most platforms.
-			template <> struct is_signed_helper<wchar_t>  : public true_type{};
-		#endif
-	#endif
-
-#if EASTL_GCC_STYLE_INT128_SUPPORTED
-			template <> struct is_signed_helper<__int128_t> : public true_type {};
+		
+#ifdef _MSC_VER
+	#pragma warning(push)
+	#pragma warning(disable: 4296)  // '<': expression is always false
+#endif
+	template<typename T, bool = is_arithmetic<T>::value>
+	struct is_signed_helper : bool_constant<T(-1) < T(0)> {};
+#ifdef _MSC_VER
+	#pragma warning(pop)
 #endif
 
+	template<typename T>
+	struct is_signed_helper<T, false> : false_type {};
+
 	template <typename T>
-	struct is_signed : public eastl::is_signed_helper<typename eastl::remove_cv<T>::type>{};
+	struct is_signed : public eastl::is_signed_helper<T>::type {};
 
 	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template <class T>
@@ -168,51 +148,31 @@ namespace eastl
 	///////////////////////////////////////////////////////////////////////
 	// is_unsigned
 	//
-	// is_unsigned<T>::value == true if and only if T is one of the following types:
-	//    [const] [volatile] char (maybe)
-	//    [const] [volatile] unsigned char
-	//    [const] [volatile] unsigned short
-	//    [const] [volatile] unsigned int
-	//    [const] [volatile] unsigned long
-	//    [const] [volatile] unsigned long long
+	// is_unsigned<T>::value == true if T is a (possibly cv-qualified) bool or unsigned integer type.
 	//
-	// Used to determine if a integral type is signed or unsigned.
+	// Used to determine if a type is unsigned.
 	// Given that there are some user-made classes which emulate integral
 	// types, we provide the EASTL_DECLARE_UNSIGNED macro to allow you to
 	// set a given class to be identified as an unsigned type.
 	///////////////////////////////////////////////////////////////////////
 
 	#define EASTL_TYPE_TRAIT_is_unsigned_CONFORMANCE 1    // is_unsigned is conforming.
-
-	template <typename T> struct is_unsigned_helper : public false_type{};
-
-	template <> struct is_unsigned_helper<unsigned char>      : public true_type{};
-	template <> struct is_unsigned_helper<unsigned short>     : public true_type{};
-	template <> struct is_unsigned_helper<unsigned int>       : public true_type{};
-	template <> struct is_unsigned_helper<unsigned long>      : public true_type{};
-	template <> struct is_unsigned_helper<unsigned long long> : public true_type{};
-
-	#if (CHAR_MAX == UCHAR_MAX)
-		template <> struct is_unsigned_helper<char>           : public true_type{};
-	#endif
-	#ifndef EA_WCHAR_T_NON_NATIVE // If wchar_t is a native type instead of simply a define to an existing type...
-		#if defined(_MSC_VER) || (defined(__WCHAR_MAX__) && ((__WCHAR_MAX__ == 4294967295U) || (__WCHAR_MAX__ == 65535))) // GCC defines __WCHAR_MAX__ for most platforms.
-			template <> struct is_unsigned_helper<wchar_t>    : public true_type{};
-		#endif
-	#endif
-
-#if defined(EA_CHAR16_NATIVE) && EA_CHAR16_NATIVE
-			template <> struct is_unsigned_helper<char16_t> : public true_type {};
+		
+#ifdef _MSC_VER
+	#pragma warning(push)
+	#pragma warning(disable: 4296)  // '<': expression is always false
 #endif
-#if defined(EA_CHAR32_NATIVE) && EA_CHAR32_NATIVE
-			template <> struct is_unsigned_helper<char32_t> : public true_type {};
+	template<typename T, bool = is_arithmetic<T>::value>
+	struct is_unsigned_helper : integral_constant<bool, T(0) < T(-1)> {};
+#ifdef _MSC_VER
+	#pragma warning(pop)
 #endif
-#if EASTL_GCC_STYLE_INT128_SUPPORTED
-			template <> struct is_unsigned_helper<__uint128_t> : public true_type {};
-#endif
+
+	template<typename T>
+	struct is_unsigned_helper<T, false> : false_type {};
 
 	template <typename T>
-	struct is_unsigned : public eastl::is_unsigned_helper<typename eastl::remove_cv<T>::type>{};
+	struct is_unsigned : public eastl::is_unsigned_helper<T>::type {};
 
 	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template <class T>
@@ -227,7 +187,53 @@ namespace eastl
 		template <> struct is_unsigned<const volatile T> : public true_type{};    \
 	}
 
+	///////////////////////////////////////////////////////////////////////
+	// is_bounded_array
+	//
+	// is_bounded_array<T>::value == true if T is an array type of known bound.
+	//
+	// is_bounded_array<int>::value is false.
+	// is_bounded_array<int[5]>::value is true.
+	// is_bounded_array<int[]>::value is false.
+	//
+	///////////////////////////////////////////////////////////////////////
 
+	#define EASTL_TYPE_TRAIT_is_bounded_array_CONFORMANCE 1    // is_bounded_array is conforming.
+
+	template<class T>
+	struct is_bounded_array: eastl::false_type {};
+
+	template<class T, size_t N>
+	struct is_bounded_array<T[N]> : eastl::true_type {};
+
+	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+		template <class T>
+		EA_CONSTEXPR bool is_bounded_array_v = is_bounded_array<T>::value;
+	#endif
+
+	///////////////////////////////////////////////////////////////////////
+	// is_unbounded_array
+	//
+	// is_unbounded_array<T>::value == true if T is an array type of known bound.
+	//
+	// is_unbounded_array<int>::value is false.
+	// is_unbounded_array<int[5]>::value is false.
+	// is_unbounded_array<int[]>::value is true.
+	//
+	///////////////////////////////////////////////////////////////////////
+
+	#define EASTL_TYPE_TRAIT_is_unbounded_array_CONFORMANCE 1    // is_unbounded_array is conforming.
+
+	template<class T>
+	struct is_unbounded_array: eastl::false_type {};
+
+	template<class T>
+	struct is_unbounded_array<T[]> : eastl::true_type {};
+
+	#if EASTL_VARIABLE_TEMPLATES_ENABLED
+		template <class T>
+		EA_CONSTEXPR bool is_unbounded_array_v = is_unbounded_array<T>::value;
+	#endif
 
 	///////////////////////////////////////////////////////////////////////
 	// alignment_of
@@ -255,7 +261,7 @@ namespace eastl
 
     ///////////////////////////////////////////////////////////////////////
 	// is_aligned
-	//
+	// 
 	// Defined as true if the type has alignment requirements greater
 	// than default alignment, which is taken to be 8. This allows for
 	// doing specialized object allocation and placement for such types.

--- a/include/EASTL/internal/type_transformations.h
+++ b/include/EASTL/internal/type_transformations.h
@@ -477,15 +477,33 @@ namespace eastl
 	// add_pointer
 	//
 	// Add pointer to a type.
-	// Provides the member typedef type which is the type T*. If T is a 
-	// reference type, then type is a pointer to the referred type. 
+	// Provides the member typedef type which is the type T*.
+	// 
+	// If T is a reference type,
+	//		type member is a pointer to the referred type.
+	// If T is an object type, a function type that is not cv- or ref-qualified,
+	// or a (possibly cv-qualified) void type,
+	//		type member is T*.
+	// Otherwise (T is a cv- or ref-qualified function type),
+	//		type member is T (ie. not a pointer).
 	//
+	// cv- and ref-qualified function types are invalid, which is why there is a specific clause for it.
+	// See https://cplusplus.github.io/LWG/issue2101 for more.
+	// 
 	///////////////////////////////////////////////////////////////////////
 
 	#define EASTL_TYPE_TRAIT_add_pointer_CONFORMANCE 1
 
-	template<class T>
-	struct add_pointer { typedef typename eastl::remove_reference<T>::type* type; };
+	namespace internal
+	{
+		template <typename T>
+		auto try_add_pointer(int) -> type_identity<typename std::remove_reference<T>::type*>;
+		template <typename T>
+		auto try_add_pointer(...) -> type_identity<T>;
+	}
+ 
+	template <typename T>
+	struct add_pointer : decltype(internal::try_add_pointer<T>(0)) {};
 
 	#if EASTL_VARIABLE_TEMPLATES_ENABLED
 		template <class T>

--- a/include/EASTL/unique_ptr.h
+++ b/include/EASTL/unique_ptr.h
@@ -536,27 +536,12 @@ namespace eastl
 	///
 	///     auto pArray = make_unique<Test[]>(4);
 	///
-	namespace Internal
-	{
-		template <typename T>
-		struct unique_type
-			{ typedef unique_ptr<T>   unique_type_single; };
-
-		template <typename T>
-		struct unique_type<T[]>
-			{ typedef unique_ptr<T[]> unique_type_unbounded_array; };
-
-		template <typename T, size_t N>
-		struct unique_type<T[N]>
-			{ typedef void            unique_type_bounded_array; };
-	}
-
 	template <typename T, typename... Args>
-	inline typename Internal::unique_type<T>::unique_type_single make_unique(Args&&... args)
+	inline typename eastl::enable_if<!eastl::is_array<T>::value, eastl::unique_ptr<T>>::type make_unique(Args&&... args)
 		{ return unique_ptr<T>(new T(eastl::forward<Args>(args)...)); }
 
 	template <typename T>
-	inline typename Internal::unique_type<T>::unique_type_unbounded_array make_unique(size_t n)
+	inline typename eastl::enable_if<eastl::is_unbounded_array<T>::value, eastl::unique_ptr<T>>::type make_unique(size_t n)
 	{
 		typedef typename eastl::remove_extent<T>::type TBase;
 		return unique_ptr<T>(new TBase[n]);
@@ -564,7 +549,7 @@ namespace eastl
 
 	// It's not possible to create a unique_ptr for arrays of a known bound (e.g. int[4] as opposed to int[]).
 	template <typename T, typename... Args>
-	typename Internal::unique_type<T>::unique_type_bounded_array
+	typename eastl::enable_if<eastl::is_bounded_array<T>::value>::type
 	make_unique(Args&&...) = delete;
 
 

--- a/test/source/TestTypeTraits.cpp
+++ b/test/source/TestTypeTraits.cpp
@@ -624,6 +624,42 @@ int TestTypeTraits()
 	EATEST_VERIFY(GetType(is_array<uint32_t*>()) == false);
 
 
+	//is_bounded_array
+	static_assert(is_bounded_array<Array>::value == true, "is_bounded_array failure");
+	EATEST_VERIFY(GetType(is_bounded_array<Array>()) == true);
+
+	static_assert(is_bounded_array<ArrayConst>::value == true,   "is_bounded_array failure");
+	EATEST_VERIFY(GetType(is_bounded_array<ArrayConst>()) == true);
+
+	static_assert(is_bounded_array<int>::value == false,        "is_bounded_array failure");
+	static_assert(is_bounded_array<int[32]>::value == true,        "is_bounded_array failure");
+	static_assert(is_bounded_array<int[]>::value == false,        "is_bounded_array failure");
+
+	static_assert(is_bounded_array<uint32_t>::value == false,    "is_bounded_array failure");
+	EATEST_VERIFY(GetType(is_bounded_array<uint32_t>()) == false);
+
+	static_assert(is_bounded_array<uint32_t*>::value == false,   "is_bounded_array failure");
+	EATEST_VERIFY(GetType(is_bounded_array<uint32_t*>()) == false);
+
+
+	//is_unbounded_array
+	static_assert(is_unbounded_array<Array>::value == false, "is_unbounded_array failure");
+	EATEST_VERIFY(GetType(is_unbounded_array<Array>()) == false);
+
+	static_assert(is_unbounded_array<ArrayConst>::value == false,   "is_unbounded_array failure");
+	EATEST_VERIFY(GetType(is_unbounded_array<ArrayConst>()) == false);
+
+	static_assert(is_unbounded_array<int>::value == false,        "is_unbounded_array failure");
+	static_assert(is_unbounded_array<int[32]>::value == false,        "is_unbounded_array failure");
+	static_assert(is_unbounded_array<int[]>::value == true,        "is_unbounded_array failure");
+
+	static_assert(is_unbounded_array<uint32_t>::value == false,    "is_unbounded_array failure");
+	EATEST_VERIFY(GetType(is_unbounded_array<uint32_t>()) == false);
+
+	static_assert(is_unbounded_array<uint32_t*>::value == false,   "is_unbounded_array failure");
+	EATEST_VERIFY(GetType(is_unbounded_array<uint32_t*>()) == false);
+
+
 	// is_reference
 	static_assert(is_reference<Class&>::value == true,        "is_reference failure");
 	EATEST_VERIFY(GetType(is_reference<Class&>()) == true);
@@ -648,6 +684,10 @@ int TestTypeTraits()
 	static_assert(is_member_function_pointer<int>::value == false,            "is_member_function_pointer failure");
 	static_assert(is_member_function_pointer<int(Class::*)>::value == false,  "is_member_function_pointer failure");
 	static_assert(is_member_function_pointer<int(Class::*)()>::value == true, "is_member_function_pointer failure");
+	static_assert(is_member_function_pointer<int(Class::*)(...)>::value == true, "is_member_function_pointer failure");
+	static_assert(is_member_function_pointer<int(Class::*)() noexcept>::value == true, "is_member_function_pointer failure");
+	static_assert(is_member_function_pointer<int(Class::*)() &>::value == true, "is_member_function_pointer failure");
+	static_assert(is_member_function_pointer<int(Class::*)() &&>::value == true, "is_member_function_pointer failure");
 
 
 	// is_member_object_pointer
@@ -660,6 +700,9 @@ int TestTypeTraits()
 	static_assert(is_member_pointer<int>::value == false,            "is_member_pointer failure");
 	static_assert(is_member_pointer<int(Class::*)>::value == true,   "is_member_pointer failure");
 	static_assert(is_member_pointer<int(Class::*)()>::value == true, "is_member_pointer failure");
+	static_assert(is_member_pointer<int(Class::* const)>::value == true, "is_member_pointer failure");
+	static_assert(is_member_pointer<int(Class::* volatile)>::value == true, "is_member_pointer failure");
+	static_assert(is_member_pointer<int(Class::* const volatile)>::value == true, "is_member_pointer failure");
 
 
 	// is_pointer
@@ -727,7 +770,7 @@ int TestTypeTraits()
 	// is_function
 	static_assert(is_function<void>::value == false,                      "is_function failure");
 	static_assert(is_function<FunctionVoidVoid>::value == true,           "is_function failure");
-	static_assert(is_function<FunctionVoidVoid&>::value == false,         "is_function failure");
+	static_assert(is_function<FunctionVoidVoid&>::value == false,		  "is_function failure");
 	static_assert(is_function<FunctionIntVoid>::value == true,            "is_function failure");
 	static_assert(is_function<FunctionIntFloat>::value == true,           "is_function failure");
 	static_assert(is_function<FunctionVoidVoidPtr>::value == false,       "is_function failure");
@@ -739,6 +782,16 @@ int TestTypeTraits()
 		// typedef int PrintfConst(const char*, ...) const;
 		static_assert(is_function<int (const char*, ...)>::value == true, "is_function failure");  // This is the signature of printf.
 	#endif
+		
+	static_assert(is_function<int (float)>::value == true, "is_function failure");
+	static_assert(is_function<int (float) const>::value == true, "is_function failure");
+	static_assert(is_function<int(float) volatile>::value == true, "is_function failure");
+	static_assert(is_function<int(float) const volatile>::value == true, "is_function failure");
+	static_assert(is_function<int(float)&>::value == true, "is_function failure");
+	static_assert(is_function<int(float)&&>::value == true, "is_function failure");
+	static_assert(is_function<int(float) noexcept>::value == true, "is_function failure");
+	static_assert(is_function<FunctionIntFloat &>::value == false, "is_function failure"); // reference to function, not a l-value reference qualified function
+	static_assert(is_function<FunctionIntFloat &&>::value == false, "is_function failure");
 
 	static_assert(is_function_v<void> == false,                           "is_function failure");
 	static_assert(is_function_v<FunctionVoidVoid> == true,                "is_function failure");
@@ -828,6 +881,8 @@ int TestTypeTraits()
 	static_assert(is_const<ConstVolatileIntReference>::value == false, "is_const failure"); // Note here that the int is const, not the reference to the int.
 	EATEST_VERIFY(GetType(is_const<ConstVolatileIntReference>()) == false);
 
+	static_assert(is_const<void() const>::value == false, "is_const failure");
+	EATEST_VERIFY(GetType(is_const<void() const>()) == false);
 
 	// is_volatile
 	static_assert(is_volatile<Int>::value == false, "is_volatile failure");
@@ -850,6 +905,9 @@ int TestTypeTraits()
 
 	static_assert(is_volatile<ConstVolatileIntReference>::value == false, "is_volatile failure"); // Note here that the int is volatile, not the reference to the int.
 	EATEST_VERIFY(GetType(is_volatile<ConstVolatileIntReference>()) == false);
+
+	static_assert(is_volatile<void() const>::value == false, "is_volatile failure");
+	EATEST_VERIFY(GetType(is_volatile<void() const>()) == false);
 
 
 	// underlying_type and to_underlying
@@ -1107,9 +1165,9 @@ int TestTypeTraits()
 	static_assert(is_unsigned_v<int32_t> == false,                 "is_unsigned failure ");
 	EATEST_VERIFY(GetType(is_unsigned<int32_t>()) == false);
 
-	static_assert(is_unsigned<bool>::value == false,               "is_unsigned failure ");
-	static_assert(is_unsigned_v<bool> == false,                    "is_unsigned failure ");
-	EATEST_VERIFY(GetType(is_unsigned<bool>()) == false);
+	static_assert(is_unsigned<bool>::value == true,                "is_unsigned failure ");
+	static_assert(is_unsigned_v<bool> == true,                     "is_unsigned failure ");
+	EATEST_VERIFY(GetType(is_unsigned<bool>()) == true);
 
 	static_assert(is_unsigned<float>::value == false,              "is_unsigned failure ");
 	static_assert(is_unsigned_v<float> == false,                   "is_unsigned failure ");
@@ -1295,6 +1353,7 @@ int TestTypeTraits()
 
 	// is_trivially_copyable
 	static_assert(is_trivially_copyable<void>::value           == false,  "is_trivially_copyable failure");
+	EATEST_VERIFY(GetType(is_trivially_copyable<void>())	   == false);
 	static_assert(is_trivially_copyable<int>::value            == true,   "is_trivially_copyable failure");
 	static_assert(is_trivially_copyable<int*>::value           == true,   "is_trivially_copyable failure");
 	static_assert(is_trivially_copyable<int[]>::value          == true,   "is_trivially_copyable failure");
@@ -1890,6 +1949,28 @@ int TestTypeTraits()
 		yValue = 3;
 		EATEST_VERIFY(yValue == 3);
 
+		// ref to T
+		//   -> T*
+		static_assert(is_same_v<add_pointer_t<int&>, int*>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<int(&)()>, int(*)()>, "add_pointer failure");
+
+		// object type (a (possibly cv-qualified) type other than function type, reference type or void), or
+		// a function type that is not cv- or ref-qualified, or a (possibly cv-qualified) void type
+		//   -> T*
+		static_assert(is_same_v<add_pointer_t<int>, int*>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<int*>, int**>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<int()>, int(*)()>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<void>, void*>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<const void>, const void*>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<volatile void>, volatile void*>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<const volatile void>, const volatile void*>, "add_pointer failure");
+
+		// otherwise (cv- or ref-qualified function type)
+		//   -> T
+		static_assert(is_same_v<add_pointer_t<int() const>, int() const>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<int() volatile>, int() volatile>, "add_pointer failure");
+		static_assert(is_same_v<add_pointer_t<int() const volatile>, int() const volatile>, "add_pointer failure");
+
 		// remove_extent
 		// If T is an array of some type X, provides the member typedef type equal to X, otherwise 
 		// type is T. Note that if T is a multidimensional array, only the first dimension is removed. 
@@ -1901,6 +1982,55 @@ int TestTypeTraits()
 		typedef int IntArray2[37][54];
 		typedef eastl::remove_all_extents<IntArray2>::type Int2;
 		static_assert((eastl::is_same<Int2, int>::value == true), "remove_all_extents/is_same failure");
+	}
+
+	// add_lvalue_reference
+	{
+		// function type with no cv- or ref-qualifier
+		//   -> T&
+		static_assert(is_same_v<add_lvalue_reference_t<void()>, void(&)()>, "add_lvalue_reference failure");
+
+		// object type (a (possibly cv-qualified) type other than function type, reference type or void)
+		//   -> T&
+		static_assert(is_same_v<add_lvalue_reference_t<int>, int&>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<const int>, const int&>, "add_lvalue_reference failure");
+
+		// if T is an rvalue reference (to some type U)
+		//   -> U&
+		static_assert(is_same_v<add_lvalue_reference_t<int&&>, int&>, "add_lvalue_reference failure");
+
+		// otherwise (cv- or ref-qualified function type, or reference type, or (possibly cv-qualified) void)
+		//   -> T
+		static_assert(is_same_v<add_lvalue_reference_t<void() const>, void() const>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<void()&>, void()&>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<void()&&>, void()&&>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<int&>, int&>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<const int&>, const int&>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<void>, void>, "add_lvalue_reference failure");
+		static_assert(is_same_v<add_lvalue_reference_t<const void>, const void>, "add_lvalue_reference failure");
+	}
+
+	// add_rvalue_reference
+	{
+		// function type with no cv- or ref-qualifier
+		//   -> T&&
+		static_assert(is_same_v<add_rvalue_reference_t<void()>, void(&&)()>, "add_rvalue_reference failure");
+
+		// object type (a (possibly cv-qualified) type other than function type, reference type or void)
+		//   -> T&&
+		static_assert(is_same_v<add_rvalue_reference_t<int>, int&&>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<const int>, const int&&>, "add_rvalue_reference failure");
+
+		// otherwise (cv- or ref-qualified function type, or reference type, or (possibly cv-qualified) void)
+		//   -> T
+		static_assert(is_same_v<add_rvalue_reference_t<void() const>, void() const>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<void()&>, void()&>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<void()&&>, void()&&>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<int&>, int&>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<int&&>, int&&>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<const int&>, const int&>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<void>, void>, "add_rvalue_reference failure");
+		static_assert(is_same_v<add_rvalue_reference_t<const void>, const void>, "add_rvalue_reference failure");
 	}
 
 
@@ -2262,8 +2392,10 @@ int TestTypeTraits()
 			static_assert(!is_aggregate_v<NotAggregrate>, "is_aggregate failure");
 		}
 
-		#ifndef EA_COMPILER_MSVC
-		// NOTE(rparolin): MSVC is incorrectly categorizing the aggregate type in this test-case.
+		#if defined(EA_COMPILER_CPP11_ENABLED) && !defined(EA_COMPILER_CPP14_ENABLED)
+		// See https://en.cppreference.com/w/cpp/language/aggregate_initialization
+		// In C++11 the requirement was added to aggregate types that no default member initializers exist,
+		// however this requirement was removed in C++14.
 		{
 			struct NotAggregrate { int data = 42; }; // default member initializer 
 			static_assert(!is_aggregate_v<NotAggregrate>, "is_aggregate failure");

--- a/test/source/main.cpp
+++ b/test/source/main.cpp
@@ -145,7 +145,7 @@ int EAMain(int argc, char* argv[])
 	testSuite.AddTest("VectorSet",				TestVectorSet);
 	testSuite.AddTest("AtomicBasic",			TestAtomicBasic);
 	testSuite.AddTest("AtomicAsm",			    TestAtomicAsm);
-	testSuite.AddTest("TestBitcast",			TestBitcast);
+	testSuite.AddTest("Bitcast",				TestBitcast);
 
 
 	nErrorCount += testSuite.Run();


### PR DESCRIPTION
Changes:
* Fix `fixed_vector_allocator`s copy constructor so it doesn't default construct the overflow allocator.
* Fix a compiler error with the new version of MSBuild related to `__analysis_assume` in combination with lambda captures and function templates.
* Fix natvis visualization of `rbtree_node`.
* Added `is_bounded_array` and `is_unbounded_array` type traits from C++20.
* Update is_trivially_copyable to have all the appropriate integral_constant members.
* make add_pointer::type well specified for cv- or ref-qualified function types. type member evaluates to T (didn't compile previously).
* is_unsigned::value now evaluates to true, to match the standard.
* is_member_pointer::value now evaluates to true for cv-qualified member pointers.
* is_const::value and is_volatile::value can now compile for cv- or ref-qualified function types.
* is_function::value now evaluates to true for l-value, r-value, const, volatile, noexcept functions and relevant combinations.
* is_member_function_pointer::value now evaluates to true for l-value, r-value, const, volatile, noexcept member functions and relevant combinations.
* change add_lvalue_reference::type and add_rvalue_reference::type to T for cv- or ref-qualified function types, to match the standard.