### PR TITLE
Add MSVC support to initializer_list

### DIFF
--- a/include/EASTL/initializer_list.h
+++ b/include/EASTL/initializer_list.h
@@ -56,6 +56,14 @@
 			initializer_list() EA_NOEXCEPT  // EA_NOEXCEPT requires a recent version of EABase.  
 			  : mpArray(NULL), mArraySize(0) { }
 
+#if defined(EA_COMPILER_MSVC)
+			// MSVC generates constructor calls with two pointers instead of one pointer + size. The constructor is
+			// public.
+			// See: https://docs.microsoft.com/en-us/cpp/standard-library/initializer-list-class#initializer_list
+			initializer_list(const_iterator pFirst, const_iterator pLast) EA_NOEXCEPT
+			  : mpArray(pFirst), mArraySize(pLast - pFirst) { }
+#endif
+
 			size_type      size()  const EA_NOEXCEPT { return mArraySize; }
 			const_iterator begin() const EA_NOEXCEPT { return mpArray; }            // Must be const_iterator, as initializer_list (and its mpArray) is an immutable temp object.
 			const_iterator end()   const EA_NOEXCEPT { return mpArray + mArraySize; }


### PR DESCRIPTION
The C++ standard does not define how the implementation constructs initializer_list instances from the actual lists. Many compilers seem to use the pointer and size method that EASTL implements, but not MSVC. It uses two pointers (the other obvious way to do it). This PR implements the corresponding constructor to make intializer_list compatible with MSVC.