### PR TITLE
Reduce complexity when inputer iterator meet RandomAccessIterator

### DIFF
--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -1960,6 +1960,10 @@ namespace eastl
 	bool identical(InputIterator1 first1, InputIterator1 last1,
 				   InputIterator2 first2, InputIterator2 last2)
 	{
+		auto d1 = eastl::distance(first1, last1);
+		auto d2 = eastl::distance(first2, last2);
+		if(d1 != d2)
+			return false;
 		while((first1 != last1) && (first2 != last2) && (*first1 == *first2))
 		{
 			++first1;
@@ -1975,6 +1979,10 @@ namespace eastl
 	bool identical(InputIterator1 first1, InputIterator1 last1,
 				   InputIterator2 first2, InputIterator2 last2, BinaryPredicate predicate)
 	{
+		auto d1 = eastl::distance(first1, last1);
+		auto d2 = eastl::distance(first2, last2);
+		if(d1 != d2)
+			return false;
 		while((first1 != last1) && (first2 != last2) && predicate(*first1, *first2))
 		{
 			++first1;


### PR DESCRIPTION
As described in https://github.com/electronicarts/EASTL/pull/514#discussion_r1255556282 , It's a X-Y problem when discussing the correct method fixing ring buffer comparation operator. Another issue to become evident.

Current `eastl::identical` is not effient enough when input iterators meet [LegacyRandomAccessIterator](https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator) requirements.

Refs: https://en.cppreference.com/w/cpp/algorithm/equal

> Complexity
> 5,7) At most min(last1 - first1, last2 - first2) applications of the predicate.
> However, if InputIt1 and InputIt2 meet the requirements of [LegacyRandomAccessIterator]> (https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator) and last1 - first1 != last2 - first2 then no applications of the predicate are made (size mismatch is detected without looking at any elements).
> 2,4,6,8) same, but the complexity is specified as O(x), rather than "at most x".


By the way, I want to know why did EASTL choose to implement the `equal` and `identical` interfaces separately at the beginning of the design, is there any reference to explain the reason?