### PR TITLE
Don't use atomic_thread_fence under TSAN

### DIFF
--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -1836,4 +1836,18 @@ typedef EASTL_SSIZE_T eastl_ssize_t; // Signed version of eastl_size_t. Concept 
 	EA_RESTORE_VC_WARNING();				\
 	EA_RESTORE_GCC_WARNING();
 
+#if defined(__has_feature)
+	#if __has_feature(thread_sanitizer)
+		#define EASTL_TSAN_ENABLED 1
+	#else
+		#define EASTL_TSAN_ENABLED 0
+	#endif
+#else
+	#if defined(__SANITIZE_THREAD__)
+		#define EASTL_TSAN_ENABLED 1
+	#else
+		#define EASTL_TSAN_ENABLED 0
+	#endif
+#endif
+
 #endif // Header include guard


### PR DESCRIPTION
TSAN is one of the best tools for checking correctness of concurrent programs out there, but sadly, it does not support atomic_thread_fence and unlikely ever will.

But for good codegen on ARM we NEED atomic_thread_fence in shared_ptr. Hence, we need to selectively use it only when TSAN is disabled and fallback to an unconditional acq_rel operation where the ARM acquire fence will be performed even when we are not releaseing the last reference. This is pretty much equivalent semantically, but avoids false-positive TSAN reports.