### PR TITLE
MSVC warning fixes 

### DIFF
--- a/scripts/CMake/CommonCppFlags.cmake
+++ b/scripts/CMake/CommonCppFlags.cmake
@@ -73,7 +73,17 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         message(FATAL_ERROR "Building with a gcc version less than 4.7.3 is not supported.")
     endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /W4 /permissive-")
+    # MSVC generates warnings when multiple /W# arguments are provided. If the parent project already specified a
+    # desired warning level we need to replace that instead of adding another warning level.
+    if(CMAKE_CXX_FLAGS MATCHES "[-/]W[0-4]")
+        string(REGEX REPLACE "[-/]W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    endif()
+    # MSVC generates warnings when multiple standards are defined. The parent project may use the CMAKE_CXX_STANDARD
+    # variable to select te standard. Unset it so that our library code is still compiled with latest.
+    unset(CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /permissive-")
 endif()
 
 


### PR DESCRIPTION
My dependent project uses `set( CMAKE_CXX_STANDARD 20 )` and has `/W0` set for libraries. This causes warnings to be generated from the EASTL sources as a result of the settings being injected by `CommonCppFlags.cmake`.

This pull request still keeps W4 for EASTL, but falls back to replacing rather than appending to prevent duplicating the /W# argument. It also unsets CMAKE_CXX_STANDARD to prevent cmake from generating a duplicate language specification.