### PR TITLE
Protect string comparisons against segfaults

### DIFF
--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -3542,6 +3542,8 @@ namespace eastl
 	template <typename T, typename Allocator>
 	inline bool operator==(const typename basic_string<T, Allocator>::value_type* p, const basic_string<T, Allocator>& b)
 	{
+		if (p == nullptr)
+			return false;
 		typedef typename basic_string<T, Allocator>::size_type string_size_type;
 		const string_size_type n = (string_size_type)CharStrlen(p);
 		return ((n == b.size()) && (Compare(p, b.data(), (size_t)n) == 0));
@@ -3551,6 +3553,8 @@ namespace eastl
 	template <typename T, typename Allocator>
 	inline bool operator==(const basic_string<T, Allocator>& a, const typename basic_string<T, Allocator>::value_type* p)
 	{
+		if (p == nullptr)
+			return false;
 		typedef typename basic_string<T, Allocator>::size_type string_size_type;
 		const string_size_type n = (string_size_type)CharStrlen(p);
 		return ((a.size() == n) && (Compare(a.data(), p, (size_t)n) == 0));

--- a/test/source/TestString.inl
+++ b/test/source/TestString.inl
@@ -2155,6 +2155,34 @@ int TEST_STRING_NAME()
 		VERIFY(LocalHash(sw2) == LocalHash(sw3));
 	}
 
+	// test == and != operators
+	{
+		StringType str1(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+		StringType str2(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+		StringType str3(LITERAL("Hello, world"));
+		typename StringType::value_type *nullChar{nullptr};
+		{
+			
+			VERIFY(!(str1 == nullptr));
+			VERIFY(!(nullptr == str1));
+			VERIFY(!(str1 == nullChar));
+			VERIFY(!(nullChar == str1));
+
+			VERIFY(str1 != nullptr);
+			VERIFY(nullptr != str1);
+			VERIFY(str1 != nullChar);
+			VERIFY(nullChar != str1);
+		}
+		{
+			VERIFY(str1 == str2);
+			VERIFY(str1 != str3);
+			VERIFY(str1 == str2.c_str());
+			VERIFY(str1 != str3.c_str());
+			VERIFY(str1.c_str() == str2);
+			VERIFY(str1.c_str() != str3);
+		}
+	}
+
 	// test <=> operator
 	#if defined(EA_COMPILER_HAS_THREE_WAY_COMPARISON)
 	{


### PR DESCRIPTION
This intends to resolve #546. 

Comparing string objects to `nullptr` is not prevented by the implementation. Therefore, it should check before starting the actual comparison - which currently leads to a segfault due to the unprotected use of `CharStrlen`. Given that `CharStrlen` fulfills the standard specification of showing UB when called like that, the issue should be fixed on the calling site.

The first commit introduces minimal test cases for the global equality operators for `basic_string`, the second the (quite small) fix.