### PR TITLE
implement EASTL_[UN]LIKELY on clang (in addition to gcc)

### DIFF
--- a/include/EASTL/internal/config.h
+++ b/include/EASTL/internal/config.h
@@ -1202,7 +1202,7 @@ namespace eastl
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef EASTL_LIKELY
-	#if defined(__GNUC__) && (__GNUC__ >= 3)
+	#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__)
 		#define EASTL_LIKELY(x)   __builtin_expect(!!(x), true)
 		#define EASTL_UNLIKELY(x) __builtin_expect(!!(x), false)
 	#else


### PR DESCRIPTION
It supported it since forever, there is no point not to use it