### PR TITLE
fix TSAN warnings about on clearing empty hashtables

### DIFF
--- a/include/EASTL/internal/hashtable.h
+++ b/include/EASTL/internal/hashtable.h
@@ -1681,12 +1681,15 @@ namespace eastl
 		for(size_type i = 0; i < n; ++i)
 		{
 			node_type* pNode = pNodeArray[i];
-			while(pNode)
+			if (!pNode)
+				continue;
+			do
 			{
 				node_type* const pTempNode = pNode;
 				pNode = pNode->mpNext;
 				DoFreeNode(pTempNode);
 			}
+			while(pNode);
 			pNodeArray[i] = NULL;
 		}
 	}


### PR DESCRIPTION
Different empty instances of hashtable (hast_map, hash_set...) are all pointing to the same global memory region `gpEmptyBucketArray`. Rewrite `hashtable<>::DoFreeNodes` in such way to avoid writing into said memory.

Caught by ThreadSanitizer on clear'ing different (but empty) hashtable instances