### PR TITLE
silence GCC's -Wuninitialized in utility.h

### DIFF
--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -27,6 +27,8 @@
 // 4217 - Member template functions cannot be used for copy-assignment or copy-construction.
 // 4512/4626 - 'class' : assignment operator could not be generated.  // This disabling would best be put elsewhere.
 EA_DISABLE_VC_WARNING(4619 4217 4512 4626);
+// Error in string's swap (error: ...‘eastl::basic_string<char, eastl::allocator>::Layout::._anon_111::raw’ is used uninitialized [-Werror=uninitialized])
+EA_DISABLE_GCC_WARNING(-Wuninitialized);
 
 
 #if defined(EA_PRAGMA_ONCE_SUPPORTED)
@@ -1019,6 +1021,7 @@ namespace eastl
 
 
 EA_RESTORE_VC_WARNING();
+EA_RESTORE_GCC_WARNING();
 
 
 #endif // Header include guard


### PR DESCRIPTION
to silence string's swap warning (perhaps only when it's part of pair?) It obviously fails compilation with -Werror (treat warnings as errors)

Full error looks like:

In file included from .../EASTL/internal/function_detail.h:22,
                 from .../EASTL/internal/function.h:14,
                 from .../EASTL/functional.h:1359,
                 ...
In function ‘void eastl::swap(T&, T&) [with T = eastl::basic_string<char, eastl::allocator>::RawLayout]’,
    inlined from ‘void eastl::basic_string<T, A>::Layout::Move(eastl::basic_string<T, A>::Layout&, eastl::basic_string<T, A>::Layout&) [with T = char; Allocator = eastl::allocator]’ at .../EASTL/string.h:486:78,
    inlined from ‘eastl::basic_string<T, A>::Layout::Layout(eastl::basic_string<T, A>::Layout&&) [with T = char; Allocator = eastl::allocator]’ at .../EASTL/string.h:399:68,
    inlined from ‘void eastl::swap(T&, T&) [with T = eastl::basic_string<char, eastl::allocator>::Layout]’ at .../EASTL/utility.h:56:5,
    inlined from ‘eastl::basic_string<T, Allocator>& eastl::basic_string<T, A>::assign(eastl::basic_string<T, A>::this_type&&) [with T = char; Allocator = eastl::allocator]’ at .../EASTL/string.h:1979:15,
    inlined from ‘eastl::basic_string<T, A>::this_type& eastl::basic_string<T, A>::operator=(eastl::basic_string<T, A>::this_type&&) [with T = char; Allocator = eastl::allocator]’ at .../EASTL/string.h:1304:16,
    inlined from ‘eastl::pair<T1, T2>& eastl::pair<T1, T2>::operator=(eastl::pair<T1, T2>&&) [with T1 = unsigned int; T2 = eastl::basic_string<char, eastl::allocator>]’ at .../EASTL/utility.h:542:28,
    inlined from ‘void eastl::swap(T&, T&) [with T = eastl::pair<unsigned int, eastl::basic_string<char, eastl::allocator> >]’ at .../EASTL/utility.h:57:5:
.../EASTL/utility.h:56:19: error: ‘temp.eastl::basic_string<char, eastl::allocator>::Layout::<unnamed>.eastl::basic_string<char, eastl::allocator>::Layout::._anon_111::raw’ is used uninitialized [-Werror=uninitialized]
   56 |                 T temp(EASTL_MOVE(a));  // EASTL_MOVE uses EASTL::move when available, else is a no-op.
      |                   ^~~~
.../EASTL/utility.h: In function ‘void eastl::swap(T&, T&) [with T = eastl::pair<unsigned int, eastl::basic_string<char, eastl::allocator> >]’:
.../EASTL/utility.h:56:19: note: ‘temp’ declared here
   56 |                 T temp(EASTL_MOVE(a));  // EASTL_MOVE uses EASTL::move when available, else is a no-op.
      |                   ^~~~

Repro-ed at least on GCC version 11.2.1 & 12.2.1