### PR TITLE
priority_queue: support storing non-copyable types in collection

### DIFF
--- a/include/EASTL/heap.h
+++ b/include/EASTL/heap.h
@@ -322,10 +322,11 @@ namespace eastl
 		typedef typename eastl::iterator_traits<RandomAccessIterator>::difference_type difference_type;
 		typedef typename eastl::iterator_traits<RandomAccessIterator>::value_type      value_type;
 
-		const value_type tempBottom(*(last - 1));
+		value_type tempBottom(eastl::forward<value_type>(*(last - 1)));
 
-		eastl::promote_heap<RandomAccessIterator, difference_type, value_type, Compare>
-						   (first, (difference_type)0, (difference_type)(last - first - 1), tempBottom, compare);
+		eastl::promote_heap<RandomAccessIterator, difference_type, value_type, Compare>(
+		    first, (difference_type)0, (difference_type)(last - first - 1), eastl::forward<value_type>(tempBottom),
+		    compare);
 	}
 
 
@@ -505,8 +506,9 @@ namespace eastl
 
 		const value_type tempBottom(*(first + heapSize - 1));
 		*(first + heapSize - 1) = *(first + position);
-		eastl::adjust_heap<RandomAccessIterator, difference_type, value_type>
-						  (first, (difference_type)0, (difference_type)(heapSize - 1), (difference_type)position, tempBottom);
+		eastl::adjust_heap<RandomAccessIterator, difference_type, value_type>(
+		    first, (difference_type)0, (difference_type)(heapSize - 1), (difference_type)position,
+		    eastl::forward<const value_type>(tempBottom));
 	}
 
 
@@ -526,10 +528,11 @@ namespace eastl
 		typedef typename eastl::iterator_traits<RandomAccessIterator>::difference_type difference_type;
 		typedef typename eastl::iterator_traits<RandomAccessIterator>::value_type      value_type;
 
-		const value_type tempBottom(*(first + heapSize - 1));
+		value_type tempBottom(*(first + heapSize - 1));
 		*(first + heapSize - 1) = *(first + position);
-		eastl::adjust_heap<RandomAccessIterator, difference_type, value_type, Compare>
-						  (first, (difference_type)0, (difference_type)(heapSize - 1), (difference_type)position, tempBottom, compare);
+		eastl::adjust_heap<RandomAccessIterator, difference_type, value_type, Compare>(
+		    first, (difference_type)0, (difference_type)(heapSize - 1), (difference_type)position,
+		    eastl::forward<const value_type>(tempBottom), compare);
 	}
 
 
@@ -554,8 +557,8 @@ namespace eastl
 
 		value_type tempBottom(*(first + heapSize - 1));
 
-		eastl::promote_heap<RandomAccessIterator, difference_type, value_type>
-						   (first, (difference_type)0, (difference_type)(heapSize - 1), tempBottom);
+		eastl::promote_heap<RandomAccessIterator, difference_type, value_type>(
+		    first, (difference_type)0, (difference_type)(heapSize - 1), eastl::forward<const value_type>(tempBottom));
 	}
 
 
@@ -574,8 +577,9 @@ namespace eastl
 
 		value_type tempBottom(*(first + heapSize - 1));
 
-		eastl::promote_heap<RandomAccessIterator, difference_type, value_type, Compare>
-						   (first, (difference_type)0, (difference_type)(heapSize - 1), tempBottom, compare);
+		eastl::promote_heap<RandomAccessIterator, difference_type, value_type, Compare>(
+		    first, (difference_type)0, (difference_type)(heapSize - 1), eastl::forward<const value_type>(tempBottom),
+		    compare);
 	}
 
 

--- a/test/source/TestExtra.cpp
+++ b/test/source/TestExtra.cpp
@@ -68,6 +68,7 @@ namespace eastl
 #include <EASTL/hash_set.h>
 #include <EASTL/random.h>
 #include <EASTL/bit.h>
+#include <EASTL/unique_ptr.h>
 #include <EASTL/core_allocator_adapter.h>
 #include <EASTL/bonus/call_traits.h>
 #include <EASTL/bonus/compressed_pair.h>
@@ -677,6 +678,110 @@ static int TestPriorityQueue()
 }
 
 
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// TestPriorityQueueNonCopyable
+// Test compilation of move-only type with priority_queue with custom comparator
+//
+
+
+class NonCopyableString : public eastl::string
+{
+public:
+	using Base = eastl::string;
+
+	using Base::Base;
+
+	NonCopyableString() = default;
+	NonCopyableString(const NonCopyableString&) = delete;
+	NonCopyableString& operator=(const NonCopyableString&) = delete;
+	NonCopyableString(NonCopyableString&&) = default;
+	NonCopyableString& operator=(NonCopyableString&&) = default;
+};
+
+
+static void TestPriorityQueueNonCopyable_DefaultComparator(int& nErrorCount)
+{
+	using Queue = eastl::priority_queue<NonCopyableString, vector<NonCopyableString>>;
+
+	Queue queue;
+	queue.push("A");
+	queue.emplace("");
+	queue.push("Mem");
+	queue.emplace("Hello World");
+
+	EATEST_VERIFY(!queue.empty());
+	EATEST_VERIFY(queue.size() == 4);
+
+	EATEST_VERIFY(queue.top() == "Mem");
+
+	queue.pop();
+	EATEST_VERIFY(queue.top() == "Hello World");
+
+	queue.pop();
+	EATEST_VERIFY(queue.top() == "A");
+
+	queue.pop();
+	EATEST_VERIFY(queue.top() == "");
+
+	queue.pop();
+	EATEST_VERIFY(queue.empty());
+}
+
+
+template <typename T = void>
+struct unique_ptr_less
+{
+	bool operator()(const unique_ptr<T>& a, const unique_ptr<T>& b) const { return *a < *b; }
+};
+
+
+static void TestPriorityQueueNonCopyable_CustomComparator(int& nErrorCount)
+{
+	using Value = unique_ptr<int>;
+	using Queue = eastl::priority_queue<Value, vector<Value>, unique_ptr_less<int>>;
+
+	Queue queue;
+
+	queue.push(eastl::make_unique<int>(5));
+	queue.emplace(eastl::make_unique<int>(1));
+	queue.push(eastl::make_unique<int>(15));
+	queue.emplace(eastl::make_unique<int>(7));
+
+	EATEST_VERIFY(!queue.empty());
+	EATEST_VERIFY(queue.size() == 4);
+
+	EATEST_VERIFY(queue.top() && *queue.top() == 15);
+
+	queue.pop();
+	EATEST_VERIFY(queue.top() && *queue.top() == 7);
+
+	queue.pop();
+	EATEST_VERIFY(queue.top() && *queue.top() == 5);
+
+	queue.pop();
+	EATEST_VERIFY(queue.top() && *queue.top() == 1);
+
+	queue.pop();
+	EATEST_VERIFY(queue.empty());
+}
+
+
+static int TestPriorityQueueNonCopyable()
+{
+	int nErrorCount = 0;
+
+	TestObject::Reset();
+
+	TestPriorityQueueNonCopyable_DefaultComparator(nErrorCount);
+
+	TestPriorityQueueNonCopyable_CustomComparator(nErrorCount);
+
+	return nErrorCount;
+}
 
 
 
@@ -1400,6 +1505,7 @@ int TestExtra()
 	nErrorCount += TestForwardDeclarations();
 	nErrorCount += TestQueue();
 	nErrorCount += TestPriorityQueue();
+	nErrorCount += TestPriorityQueueNonCopyable();
 	nErrorCount += TestStack();
 	nErrorCount += TestCompressedPair();
 	nErrorCount += TestCallTraits();


### PR DESCRIPTION
Previously compilation error was generated while trying to add non-copyable item into `eastl::priority_queue` collection.

