### PR TITLE
forward declare std::tuple_size/tuple_element at least on msvc

### DIFF
--- a/include/EASTL/array.h
+++ b/include/EASTL/array.h
@@ -660,9 +660,17 @@ namespace eastl
 ///////////////////////////////////////////////////////////////////////
 
 #ifndef EA_COMPILER_NO_STRUCTURED_BINDING
+#ifdef EA_COMPILER_MSVC
+	namespace std
+	{
+		template <class> struct tuple_size;
+		template <size_t, class> struct tuple_element;
+	}
+#else
 // we can't forward declare tuple_size and tuple_element because some std implementations
 // don't declare it in the std namespace, but instead alias it.
 #include <array>
+#endif
 
 namespace std
 {

--- a/include/EASTL/tuple.h
+++ b/include/EASTL/tuple.h
@@ -968,9 +968,17 @@ EA_CONSTEXPR decltype(auto) apply(F&& f, Tuple&& t)
 // C++17 structured bindings support for eastl::tuple
 //
 #ifndef EA_COMPILER_NO_STRUCTURED_BINDING
+#ifdef EA_COMPILER_MSVC
+	namespace std
+	{
+		template <class> struct tuple_size;
+		template <size_t, class> struct tuple_element;
+	}
+#else
 // we can't forward declare tuple_size and tuple_element because some std implementations
 // don't declare it in the std namespace, but instead alias it.
 #include <tuple>
+#endif
 
 	namespace std
 	{

--- a/include/EASTL/utility.h
+++ b/include/EASTL/utility.h
@@ -999,9 +999,17 @@ namespace eastl
 // C++17 structured bindings support for eastl::pair
 //
 #ifndef EA_COMPILER_NO_STRUCTURED_BINDING
+#ifdef EA_COMPILER_MSVC
+	namespace std
+	{
+		template <class> struct tuple_size;
+		template <size_t, class> struct tuple_element;
+	}
+#else
 // we can't forward declare tuple_size and tuple_element because some std implementations
 // don't declare it in the std namespace, but instead alias it.
 #include <utility>
+#endif
 
 	namespace std
 	{


### PR DESCRIPTION
...instead of including std headers. This ways we save compilation times AND prevent unathorized use of std containers 