### PR TITLE
remove inclusion of <intrin.h> from algorithm.h

### DIFF
--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -255,10 +255,6 @@
 
 EA_DISABLE_ALL_VC_WARNINGS();
 
-	#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_X86_64))
-		#include <intrin.h>
-	#endif
-
 	#include <stddef.h>
 	#include <string.h> // memcpy, memcmp, memmove
 

--- a/include/EASTL/bitset.h
+++ b/include/EASTL/bitset.h
@@ -48,7 +48,18 @@ EA_DISABLE_VC_WARNING(4127); // Conditional expression is constant
 	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
 #endif
 
-
+#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_ARM64))
+extern "C" unsigned char _BitScanReverse(unsigned long *_Index, unsigned long _Mask);
+extern "C" unsigned char _BitScanForward(unsigned long *_Index, unsigned long _Mask);
+#pragma intrinsic(_BitScanReverse)
+#pragma intrinsic(_BitScanForward)
+#if defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_ARM64)
+extern "C" unsigned char _BitScanReverse64(unsigned long *_Index, unsigned __int64 _Mask);
+extern "C" unsigned char _BitScanForward64(unsigned long *_Index, unsigned __int64 _Mask);
+#pragma intrinsic(_BitScanReverse64)
+#pragma intrinsic(_BitScanForward64)
+#endif
+#endif
 
 namespace eastl
 {
@@ -649,7 +660,7 @@ namespace eastl
 	template<typename UInt32>
 	eastl::enable_if_t<detail::is_word_type_v<UInt32> && sizeof(UInt32) == 4, uint32_t> GetFirstBit(UInt32 x)
 	{
-#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_X86_64))
+#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_ARM64))
 		// This has been benchmarked as significantly faster than the generic code below.
 		unsigned char isNonZero;
 		unsigned long index;
@@ -679,7 +690,7 @@ namespace eastl
 	template<typename UInt64>
 	eastl::enable_if_t<detail::is_word_type_v<UInt64> && sizeof(UInt64) == 8, uint32_t> GetFirstBit(UInt64 x)
 	{
-#if defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86_64)
+#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_ARM64))
 		// This has been benchmarked as significantly faster than the generic code below.
 		unsigned char isNonZero;
 		unsigned long index;
@@ -767,7 +778,7 @@ namespace eastl
 	template<typename UInt32>
 	eastl::enable_if_t<detail::is_word_type_v<UInt32> && sizeof(UInt32) == 4, uint32_t> GetLastBit(UInt32 x)
 	{
-#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_X86_64))
+#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_ARM64))
 		// This has been benchmarked as significantly faster than the generic code below.
 		unsigned char isNonZero;
 		unsigned long index;
@@ -798,7 +809,7 @@ namespace eastl
 	template<typename UInt64>
 	eastl::enable_if_t<detail::is_word_type_v<UInt64> && sizeof(UInt64) == 8, uint32_t> GetLastBit(UInt64 x)
 	{
-#if defined(EA_COMPILER_MSVC) && defined(EA_PROCESSOR_X86_64)
+#if defined(EA_COMPILER_MSVC) && (defined(EA_PROCESSOR_X86_64) || defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_ARM64))
 		// This has been benchmarked as significantly faster than the generic code below.
 		unsigned char isNonZero;
 		unsigned long index;

--- a/include/EASTL/internal/fill_help.h
+++ b/include/EASTL/internal/fill_help.h
@@ -14,7 +14,14 @@
 #include <EASTL/internal/config.h>
 
 #if defined(EA_COMPILER_MICROSOFT) && (defined(EA_PROCESSOR_X86) || defined(EA_PROCESSOR_X86_64))
-#include <intrin.h>
+extern "C" void __stosw(unsigned short *, unsigned short, size_t);
+extern "C" void __stosd(unsigned long *, unsigned long, size_t);
+#pragma intrinsic(__stosw)
+#pragma intrinsic(__stosd)
+#ifdef EA_PROCESSOR_X86_64
+extern "C" void __stosq(unsigned __int64 *, unsigned __int64, size_t);
+#pragma intrinsic(__stosq)
+#endif
 #endif
 
 namespace eastl


### PR DESCRIPTION
Do forward declare all necessary intrinsic funcs in-place to avoid including <intrin.h> as on clang-cl it's includes a lot of headers.

Also enable accelerated intrin code path on arm64 in bitset<>