### PR TITLE
fix(clang): Correct literal operator in string_view.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,8 @@ target_include_directories(EASTL PUBLIC include)
 #-------------------------------------------------------------------------------------------
 FetchContent_Declare(
   EABase
-  GIT_REPOSITORY https://github.com/electronicarts/EABase.git
-  GIT_TAG        123363eb82e132c0181ac53e43226d8ee76dea12
+  GIT_REPOSITORY https://github.com/vikhik/EABase.git
+  GIT_TAG        c40192f
   GIT_SUBMODULES "" # This should be temporary until we update the cyclic submodule dependencies in EABase.
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------------------
 # Copyright (C) Electronic Arts Inc.  All rights reserved.
 #-------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.11...3.30)
 include(FetchContent)
 project(EASTL CXX)
 

--- a/include/EASTL/string_view.h
+++ b/include/EASTL/string_view.h
@@ -694,10 +694,10 @@ namespace eastl
 				// Temporarily disable the warning until we figure out why it thinks _sv is "at global scope".
 				EA_DISABLE_CLANG_WARNING(-Wreserved-identifier)
 				// Backwards compatibility.
-			    EA_CONSTEXPR inline string_view operator "" _sv(const char* str, size_t len) EA_NOEXCEPT { return {str, len}; }
-			    EA_CONSTEXPR inline u16string_view operator "" _sv(const char16_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
-			    EA_CONSTEXPR inline u32string_view operator "" _sv(const char32_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
-			    EA_CONSTEXPR inline wstring_view operator "" _sv(const wchar_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+			    EA_CONSTEXPR inline string_view operator ""_sv(const char* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+			    EA_CONSTEXPR inline u16string_view operator ""_sv(const char16_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+			    EA_CONSTEXPR inline u32string_view operator ""_sv(const char32_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
+			    EA_CONSTEXPR inline wstring_view operator ""_sv(const wchar_t* str, size_t len) EA_NOEXCEPT { return {str, len}; }
 				EA_RESTORE_CLANG_WARNING()	// -Wreserved-identifier
 
 				// C++20 char8_t support.


### PR DESCRIPTION
Fix a new warning in clang (18?) - `-Wdeprecated-literal-operator`

ref: https://github.com/fmtlib/fmt/issues/3607