### PR TITLE
Revive the branch in the implementation of eastl::atomic compare_exchange for the MSVC backend.

### DIFF
--- a/include/EASTL/internal/atomic/compiler/msvc/compiler_msvc.h
+++ b/include/EASTL/internal/atomic/compiler/msvc/compiler_msvc.h
@@ -161,8 +161,15 @@ struct FixedWidth128
 											comparandIntegral, EASTL_ATOMIC_TYPE_PUN_CAST(integralType, (desired)), \
 											MemoryOrder, cmpxchgStrongIntrinsic); \
 																		\
-		*(expected) = EASTL_ATOMIC_TYPE_PUN_CAST(type, oldIntegral);    \
-		ret = (oldIntegral == comparandIntegral);						\
+		if (oldIntegral == comparandIntegral)							\
+		{																\
+			ret = true;													\
+		}																\
+		else															\
+		{																\
+			*(expected) = EASTL_ATOMIC_TYPE_PUN_CAST(type, oldIntegral); \
+			ret = false;												\
+		}																\
 	}
 
 /**


### PR DESCRIPTION
This should fix #580.
See https://herbsutter.com/2014/02/19/reader-qa-is-stdatomic_compare_exchange_-implementable/ for some related discussion on why this is necessary, [this comment](https://herbsutter.com/2014/02/19/reader-qa-is-stdatomic_compare_exchange_-implementable/#comment-15605) is particularly enlightening. 