### PR TITLE
basic_string::starts_with() / basic_string::ends_with()

### DIFF
--- a/include/EASTL/string.h
+++ b/include/EASTL/string.h
@@ -719,6 +719,16 @@ namespace eastl
 		size_type find_last_not_of(const value_type* p, size_type position, size_type n) const;
 		size_type find_last_not_of(value_type c, size_type position = npos) const EA_NOEXCEPT;
 
+		// Starts with operations
+		bool starts_with(view_type sv) const EA_NOEXCEPT;
+		bool starts_with(value_type c) const EA_NOEXCEPT;
+		bool starts_with(const value_type* p) const;
+
+		// Ends with operations
+		bool ends_with(view_type sv) const EA_NOEXCEPT;
+		bool ends_with(value_type c) const EA_NOEXCEPT;
+		bool ends_with(const value_type* p) const;
+
 		// Substring functionality
 		this_type substr(size_type position = 0, size_type n = npos) const;
 
@@ -2938,6 +2948,68 @@ namespace eastl
 				return (size_type)((pResult - 1) - internalLayout().BeginPtr());
 		}
 		return npos;
+	}
+
+
+	template <typename T, typename Allocator>
+	bool basic_string<T, Allocator>::starts_with(view_type sv) const EA_NOEXCEPT
+	{
+		const size_type nOtherLength = sv.size();
+
+		if(nOtherLength > internalLayout().GetSize())
+			return false;
+
+		return Compare(internalLayout().BeginPtr(), sv.begin(), (size_t)nOtherLength) == 0;
+	}
+
+
+	template <typename T, typename Allocator>
+	bool basic_string<T, Allocator>::starts_with(value_type c) const EA_NOEXCEPT
+	{
+		return internalLayout().GetSize() > 0 && *internalLayout().BeginPtr() == c;
+	}
+
+
+	template <typename T, typename Allocator>
+	bool basic_string<T, Allocator>::starts_with(const value_type* p) const
+	{
+		const size_type nOtherLength = (size_type)CharStrlen(p);
+
+		if(nOtherLength > internalLayout().GetSize())
+			return false;
+
+		return Compare(internalLayout().BeginPtr(), p, (size_t)nOtherLength) == 0;
+	}
+
+
+	template <typename T, typename Allocator>
+	bool basic_string<T, Allocator>::ends_with(view_type sv) const EA_NOEXCEPT
+	{
+		const size_type nOtherLength = sv.size();
+
+		if(nOtherLength > internalLayout().GetSize())
+			return false;
+
+		return Compare(internalLayout().EndPtr() - nOtherLength, sv.begin(), (size_t)nOtherLength) == 0;
+	}
+
+
+	template <typename T, typename Allocator>
+	bool basic_string<T, Allocator>::ends_with(value_type c) const EA_NOEXCEPT
+	{
+		return internalLayout().GetSize() > 0 && *(internalLayout().EndPtr() - 1) == c;
+	}
+
+
+	template <typename T, typename Allocator>
+	bool basic_string<T, Allocator>::ends_with(const value_type* p) const
+	{
+		const size_type nOtherLength = (size_type)CharStrlen(p);
+
+		if(nOtherLength > internalLayout().GetSize())
+			return false;
+
+		return Compare(internalLayout().EndPtr() - nOtherLength, p, (size_t)nOtherLength) == 0;
 	}
 
 

--- a/test/source/TestString.inl
+++ b/test/source/TestString.inl
@@ -1824,6 +1824,72 @@ int TEST_STRING_NAME()
 		VERIFY(str.find_last_not_of(LITERAL('a')) == 28);
 	}
 
+	// bool starts_with(const view_type x) const EA_NOEXCEPT;
+	// bool starts_with(value_type c) const EA_NOEXCEPT;
+	// bool starts_with(const value_type* p) const;
+	{
+		StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+	    using view_type = typename StringType::view_type;
+
+	    VERIFY(str.starts_with(view_type(LITERAL("abc"))));
+	    VERIFY(str.starts_with(view_type(LITERAL("abcdef"))));
+	    VERIFY(str.starts_with(view_type(LITERAL("abcdefghijklmnopqrstuvwxyz"))));
+	    VERIFY(!str.starts_with(view_type(LITERAL("xyz"))));
+	    VERIFY(!str.starts_with(view_type(LITERAL("bcd"))));
+	    VERIFY(!str.starts_with(view_type(LITERAL("abcdefghijklmnopqrstuvwxyz123"))));
+
+		VERIFY(str.starts_with(LITERAL("abc")));
+		VERIFY(str.starts_with(LITERAL("abcdef")));
+		VERIFY(str.starts_with(LITERAL("abcdefghijklmnopqrstuvwxyz")));
+		VERIFY(!str.starts_with(LITERAL("xyz")));
+		VERIFY(!str.starts_with(LITERAL("bcd")));
+		VERIFY(!str.starts_with(LITERAL("abcdefghijklmnopqrstuvwxyz123")));
+
+		VERIFY(str.starts_with(LITERAL('a')));
+		VERIFY(!str.starts_with(LITERAL('b')));
+		VERIFY(!str.starts_with(LITERAL('z')));
+
+		StringType empty;
+		VERIFY(empty.starts_with(StringType(LITERAL(""))));
+		VERIFY(empty.starts_with(LITERAL("")));
+		VERIFY(!empty.starts_with(LITERAL('a')));
+		VERIFY(str.starts_with(StringType(LITERAL(""))));
+		VERIFY(str.starts_with(LITERAL("")));
+	}
+
+	// bool ends_with(const view_type x) const EA_NOEXCEPT;
+	// bool ends_with(value_type c) const EA_NOEXCEPT;
+	// bool ends_with(const value_type* p) const;
+	{
+		StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));
+		using view_type = typename StringType::view_type;
+
+		VERIFY(str.ends_with(view_type(LITERAL("xyz"))));
+		VERIFY(str.ends_with(view_type(LITERAL("uvwxyz"))));
+		VERIFY(str.ends_with(view_type(LITERAL("abcdefghijklmnopqrstuvwxyz"))));
+		VERIFY(!str.ends_with(view_type(LITERAL("abc"))));
+		VERIFY(!str.ends_with(view_type(LITERAL("wxy"))));
+		VERIFY(!str.ends_with(view_type(LITERAL("123abcdefghijklmnopqrstuvwxyz"))));
+
+		VERIFY(str.ends_with(LITERAL("xyz")));
+		VERIFY(str.ends_with(LITERAL("uvwxyz")));
+		VERIFY(str.ends_with(LITERAL("abcdefghijklmnopqrstuvwxyz")));
+		VERIFY(!str.ends_with(LITERAL("abc")));
+		VERIFY(!str.ends_with(LITERAL("wxy")));
+		VERIFY(!str.ends_with(LITERAL("123abcdefghijklmnopqrstuvwxyz")));
+
+		VERIFY(str.ends_with(LITERAL('z')));
+		VERIFY(!str.ends_with(LITERAL('y')));
+		VERIFY(!str.ends_with(LITERAL('a')));
+
+		StringType empty;
+		VERIFY(empty.ends_with(StringType(LITERAL(""))));
+		VERIFY(empty.ends_with(LITERAL("")));
+		VERIFY(!empty.ends_with(LITERAL('z')));
+		VERIFY(str.ends_with(StringType(LITERAL(""))));
+		VERIFY(str.ends_with(LITERAL("")));
+	}
+
 	// this_type substr(size_type position = 0, size_type n = npos) const;
 	{
 		StringType str(LITERAL("abcdefghijklmnopqrstuvwxyz"));


### PR DESCRIPTION
Implements C++20 string methods starts_with() and ends_with() with three
overloads each:
- bool starts_with(view_type sv) const EA_NOEXCEPT;
- bool starts_with(value_type c) const EA_NOEXCEPT;
- bool starts_with(const value_type* p) const;

And corresponding ends_with() methods.

Includes comprehensive unit tests covering all overloads and edge cases.

https://en.cppreference.com/w/cpp/string/basic_string/starts_with https://en.cppreference.com/w/cpp/string/basic_string/ends_with