### PR TITLE
Add debug assertions to lru_cache

### DIFF
--- a/include/EASTL/bonus/lru_cache.h
+++ b/include/EASTL/bonus/lru_cache.h
@@ -274,11 +274,19 @@ namespace eastl
 		/// Removes the oldest entry from the cache.
 		void erase_oldest()
 		{
+			#if EASTL_ASSERT_ENABLED
+				if (EASTL_UNLIKELY(empty()))
+					EASTL_FAIL_MSG("lru_cache::erase_oldest -- empty container");
+			#endif
+
 			auto key = m_list.back();
 			m_list.pop_back();
 
 			// Delete the actual entry
 			auto iter = m_map.find(key);
+
+			// m_list and m_map must be in sync; every key in m_list exists in m_map.
+			EASTL_ASSERT(iter != m_map.end());
 			map_erase(iter);
 		}
 
@@ -304,6 +312,11 @@ namespace eastl
 		/// Touches key at iterator iter, moving it to most recently used position
 		void touch(iterator& iter)
 		{
+			#if EASTL_ASSERT_ENABLED
+				if (EASTL_UNLIKELY(iter == m_map.end()))
+					EASTL_FAIL_MSG("lru_cache::touch -- invalid iterator");
+			#endif
+
 			auto listRef = iter->second.second;
 
 			m_list.erase(listRef);
@@ -334,6 +347,11 @@ namespace eastl
 		/// Updates data at spot iter with data v.
 		void assign(iterator& iter, const value_type& v)
 		{
+			#if EASTL_ASSERT_ENABLED
+				if (EASTL_UNLIKELY(iter == m_map.end()))
+					EASTL_FAIL_MSG("lru_cache::assign -- invalid iterator");
+			#endif
+
 			if (m_delete_callback)
 				m_delete_callback(iter->second.first);
 			touch(iter);
@@ -372,7 +390,7 @@ namespace eastl
 		/// Resizes the cache.  Can be used to either expand or contract the cache.
 		/// In the case of a contraction, the oldest entries will be evicted with their respective
 		/// deletors called before completing.
-		void resize(size_type newSize)	
+		void resize(size_type newSize)
 		{
 			m_capacity = newSize;
 			trim();
@@ -415,6 +433,9 @@ namespace eastl
 
 		void make_space()
 		{
+			// A zero-capacity cache cannot hold any entries; inserting into one is invalid.
+			EASTL_ASSERT(m_capacity > 0);
+
 			if (size() == m_capacity)
 			{
 				erase_oldest();

--- a/include/EASTL/bonus/lru_cache.h
+++ b/include/EASTL/bonus/lru_cache.h
@@ -131,6 +131,11 @@ namespace eastl
 		}
 
 		// TODO(rparolin):  Why do we prevent copies? And what about moves?
+		// Copies are likely disallowed because m_map stores iterators into m_list, so a memberwise
+		// copy would leave the copy's map referencing the source's list; a correct copy would need
+		// to rebuild those iterators against the copied list. Declaring the copy functions also
+		// suppresses the implicit move functions; moves could be supported (both members are
+		// node-based containers whose iterators remain valid across a move) but have not been needed.
 		lru_cache(const this_type&) = delete;
 		this_type &operator=(const this_type&) = delete;
 


### PR DESCRIPTION
# Add debug assertions to lru_cache

lru_cache did no debug checking, unlike list_map, queue, stack and ring_buffer. This adds the same assert patterns those containers already use:

* erase_oldest() now asserts on an empty container, same as list_map::pop_back and queue::pop. It also asserts that the list and map are still in sync before erasing from the map.
* touch(iterator&) and assign(iterator&, v) now assert when passed end(), same as the invalid iterator checks in deque::erase and vector::erase. The assign check fires before the user delete callback would be invoked on a garbage value.
* make_space() now asserts m_capacity > 0, so inserting into a zero capacity cache (constructed with 0, from an empty initializer list, or after resize(0)) fails at the root cause instead of as a confusing empty container assert during eviction.

Also adds an answer to the existing TODO about why copies are deleted: m_map stores iterators into m_list, so a memberwise copy would leave the copy's map referencing the source's list. The TODO is kept since the rationale is inferred.

Release builds are unchanged, all checks compile out. Zero capacity insert was already undefined behavior in every configuration (list::back on an empty list); in debug builds it now fails immediately with a clear message. The key based overloads (touch(key), assign(key, v), erase(key)) are unchanged, they already validate via find() and return false.

Tested with the full EASTLTest suite in a Debug MSVC build. Each new assert was also negative tested by overriding the assert macros to throw: all four fire with the expected message, and normal use (insert, evict, touch, assign, clear) fires none.

Two adjacent issues noticed while here, left out of scope. First, rbegin/rend/crbegin/crend forward to m_map.rbegin() etc., but the default unordered_map backing is forward-only and has no such members. These only compile today because no code ever calls them, so the bodies are never instantiated; the first caller gets an error inside the header. They also declare their return type as iterator rather than reverse_iterator, so swapping in a map that does support reverse iteration would not fix them. They probably want to be removed. Second, lru_cache implements no validate()/validate_iterator(), although the FAQ states all containers have them (the other bonus containers like list_map and ring_buffer do). Those would be the fuller answer to stale iterator misuse than the end() checks added here.